### PR TITLE
Make the `const-random` dependency optional

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,13 @@ doctest = true
 bench = true
 doc = true
 
+[features]
+default = ["compile-time-rng"]
+
+# Disabling this feature will make the `ABuildHasher::new` use a preset seed
+# and disable the `Default` impl for `AHasher`
+compile-time-rng = ["const-random"]
+
 [[bench]]
 name = "ahash"
 path = "tests/bench.rs"
@@ -41,7 +48,7 @@ debug-assertions = false
 codegen-units = 1
 
 [dependencies]
-const-random = "0.1.6"
+const-random = { version = "0.1.6", optional = true }
 no-panic = { version = "0.1.10", optional = true }
 
 [dev-dependencies]

--- a/src/aes_hash.rs
+++ b/src/aes_hash.rs
@@ -178,12 +178,14 @@ mod tests {
     use std::collections::HashMap;
     use std::hash::BuildHasherDefault;
 
+    #[cfg(feature = "compile-time-rng")]
     #[test]
     fn test_builder() {
         let mut map = HashMap::<u32, u64, BuildHasherDefault<AHasher>>::default();
         map.insert(1, 3);
     }
 
+    #[cfg(feature = "compile-time-rng")]
     #[test]
     fn test_default() {
         let hasher_a = AHasher::default();

--- a/src/aes_hash.rs
+++ b/src/aes_hash.rs
@@ -21,6 +21,12 @@ pub struct AHasher {
 }
 
 impl AHasher {
+    /// Creates a new hasher keyed to the provided key.
+    #[inline]
+    pub fn new_with_key(key: u64) -> AHasher {
+        AHasher { buffer: [key, !key] }
+    }
+
     /// Creates a new hasher keyed to the provided keys.
     /// # Example
     ///

--- a/src/fallback_hash.rs
+++ b/src/fallback_hash.rs
@@ -31,7 +31,7 @@ impl AHasher {
 
     /// Creates a new hasher keyed to the provided keys.
     #[inline]
-    pub(crate) fn new_with_keys(key1: u64, key2: u64) -> AHasher {
+    pub fn new_with_keys(key1: u64, key2: u64) -> AHasher {
         AHasher {
             buffer: key1 ^ (key2.rotate_left(ROT)),
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -246,4 +246,10 @@ mod test {
         let bytes: u64 = as_array!(input, 8).convert();
         assert_eq!(bytes, 0x6464646464646464);
     }
+
+    #[test]
+    fn test_ahasher_construction() {
+        let _ = AHasher::new_with_key(1234);
+        let _ = AHasher::new_with_keys(1245, 5678);
+    }
 }


### PR DESCRIPTION
Not everyone needs this, and the `const-random` adds a few extra relatively heavy dependencies which does cost build time, so I'd be nice to be able to disable it.

This also has the side effect of enabling reproducible builds, though, obviously, at a cost.