### PR TITLE
No panic opt

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ codegen-units = 1
 const-random = "0.1.6"
 
 [dev-dependencies]
-no-panic = "0.1.10"
+no-panic = { version = "0.1.10", optional = true }
 criterion = "0.2.10"
 seahash = "3.0.5"
 fnv = "1.0.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,9 +42,9 @@ codegen-units = 1
 
 [dependencies]
 const-random = "0.1.6"
+no-panic = { version = "0.1.10", optional = true }
 
 [dev-dependencies]
-no-panic = { version = "0.1.10", optional = true }
 criterion = "0.2.10"
 seahash = "3.0.5"
 fnv = "1.0.5"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,7 @@
 #![cfg_attr(not(test), no_std)]
 //#![feature(core_intrinsics)]
 extern crate const_random;
-#[cfg(test)]
+#[cfg(all(test, feature = "no_panic"))]
 extern crate no_panic;
 
 #[macro_use]
@@ -29,7 +29,7 @@ use const_random::const_random;
 use core::hash::BuildHasher;
 use core::sync::atomic::AtomicUsize;
 use core::sync::atomic::Ordering;
-#[cfg(test)]
+#[cfg(all(test, feature = "no_panic"))]
 use no_panic::no_panic;
 
 #[cfg(all(any(target_arch = "x86", target_arch = "x86_64"), target_feature = "aes"))]
@@ -191,7 +191,7 @@ impl BuildHasher for ABuildHasher {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "no_panic"))]
 #[inline(never)]
 #[no_panic]
 #[no_mangle]
@@ -212,6 +212,7 @@ mod test {
     use core::hash::BuildHasherDefault;
     use std::collections::HashMap;
 
+    #[cfg(feature = "no_panic")]
     #[test]
     fn test_no_panic() {
         hash_test_final(2, "");


### PR DESCRIPTION
This patch was necessary to fix our build

My understanding is that llvm uses lots of heuristics to decide what optimizations to run and when -- so its possible that if the translation unit becomes large enough, it may stop doing optimizations that it would do in smaller files, and then cause `no_panic` assertions to fail. So I think in general the user of the library needs a way to turn off these assertions -- if they are on, there are expected to be some programs that would break, no matter how optimization-friendly the code is.

Solves #19 