### PR TITLE
Add `AHashMap` and `AHashSet`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,9 @@ doc = true
 [features]
 default = ["compile-time-rng"]
 
+# Enabling this will enable `AHashMap` and `AHashSet`
+std = []
+
 # Disabling this feature will make the `ABuildHasher::new` use a preset seed
 # and disable the `Default` impl for `AHasher`
 compile-time-rng = ["const-random"]
@@ -62,3 +65,4 @@ rand = "0.6.5"
 [package.metadata.docs.rs]
 rustc-args = ["-C", "target-feature=+aes"]
 rustdoc-args = ["-C", "target-feature=+aes"]
+features = ["std"]

--- a/src/hash_map.rs
+++ b/src/hash_map.rs
@@ -1,0 +1,177 @@
+use std::borrow::Borrow;
+use std::collections::{hash_map, HashMap};
+use std::fmt::{self, Debug};
+use std::hash::{BuildHasher, Hash};
+use std::iter::FromIterator;
+use std::ops::{Deref, DerefMut, Index};
+use std::panic::UnwindSafe;
+
+/// A [`HashMap`](std::collections::HashMap) using [`ABuildHasher`](crate::ABuildHasher) to hash the items.
+/// Requires the `std` feature to be enabled.
+#[derive(Clone)]
+pub struct AHashMap<K, V, S = crate::ABuildHasher>(HashMap<K, V, S>);
+
+impl<K, V, S> AHashMap<K, V, S>
+where
+    K: Hash + Eq,
+    S: BuildHasher + Default,
+{
+    pub fn new() -> Self {
+        AHashMap(HashMap::with_hasher(S::default()))
+    }
+
+    pub fn with_capacity(capacity: usize) -> Self {
+        AHashMap(HashMap::with_capacity_and_hasher(capacity, S::default()))
+    }
+}
+
+impl<K, V, S> AHashMap<K, V, S>
+where
+    K: Hash + Eq,
+    S: BuildHasher,
+{
+    pub fn with_hasher(hash_builder: S) -> Self {
+        AHashMap(HashMap::with_hasher(hash_builder))
+    }
+
+    pub fn with_capacity_and_hasher(capacity: usize, hash_builder: S) -> Self {
+        AHashMap(HashMap::with_capacity_and_hasher(capacity, hash_builder))
+    }
+}
+
+impl<K, V, S> Deref for AHashMap<K, V, S> {
+    type Target = HashMap<K, V, S>;
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<K, V, S> DerefMut for AHashMap<K, V, S> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+impl<K, V, S> UnwindSafe for AHashMap<K, V, S>
+where
+    K: UnwindSafe,
+    V: UnwindSafe,
+{
+}
+
+impl<K, V, S> PartialEq for AHashMap<K, V, S>
+where
+    K: Eq + Hash,
+    V: PartialEq,
+    S: BuildHasher,
+{
+    fn eq(&self, other: &AHashMap<K, V, S>) -> bool {
+        self.0.eq(&other.0)
+    }
+}
+
+impl<K, V, S> Eq for AHashMap<K, V, S>
+where
+    K: Eq + Hash,
+    V: Eq,
+    S: BuildHasher,
+{
+}
+
+impl<K, Q: ?Sized, V, S> Index<&Q> for AHashMap<K, V, S>
+where
+    K: Eq + Hash + Borrow<Q>,
+    Q: Eq + Hash,
+    S: BuildHasher,
+{
+    type Output = V;
+
+    /// Returns a reference to the value corresponding to the supplied key.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the key is not present in the `HashMap`.
+    #[inline]
+    fn index(&self, key: &Q) -> &V {
+        self.0.index(key)
+    }
+}
+
+impl<K, V, S> Debug for AHashMap<K, V, S>
+where
+    K: Eq + Hash + Debug,
+    V: Debug,
+    S: BuildHasher,
+{
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        self.0.fmt(fmt)
+    }
+}
+
+impl<K, V, S> FromIterator<(K, V)> for AHashMap<K, V, S>
+where
+    K: Eq + Hash,
+    S: BuildHasher + Default,
+{
+    fn from_iter<T: IntoIterator<Item = (K, V)>>(iter: T) -> Self {
+        AHashMap(HashMap::from_iter(iter))
+    }
+}
+
+impl<'a, K, V, S> IntoIterator for &'a AHashMap<K, V, S> {
+    type Item = (&'a K, &'a V);
+    type IntoIter = hash_map::Iter<'a, K, V>;
+    fn into_iter(self) -> Self::IntoIter {
+        (&self.0).into_iter()
+    }
+}
+
+impl<'a, K, V, S> IntoIterator for &'a mut AHashMap<K, V, S> {
+    type Item = (&'a K, &'a mut V);
+    type IntoIter = hash_map::IterMut<'a, K, V>;
+    fn into_iter(self) -> Self::IntoIter {
+        (&mut self.0).into_iter()
+    }
+}
+
+impl<K, V, S> IntoIterator for AHashMap<K, V, S> {
+    type Item = (K, V);
+    type IntoIter = hash_map::IntoIter<K, V>;
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.into_iter()
+    }
+}
+
+impl<K, V, S> Extend<(K, V)> for AHashMap<K, V, S>
+where
+    K: Eq + Hash,
+    S: BuildHasher,
+{
+    #[inline]
+    fn extend<T: IntoIterator<Item = (K, V)>>(&mut self, iter: T) {
+        self.0.extend(iter)
+    }
+}
+
+impl<'a, K, V, S> Extend<(&'a K, &'a V)> for AHashMap<K, V, S>
+where
+    K: Eq + Hash + Copy + 'a,
+    V: Copy + 'a,
+    S: BuildHasher,
+{
+    #[inline]
+    fn extend<T: IntoIterator<Item = (&'a K, &'a V)>>(&mut self, iter: T) {
+        self.0.extend(iter)
+    }
+}
+
+impl<K, V, S> Default for AHashMap<K, V, S>
+where
+    K: Eq + Hash,
+    S: BuildHasher + Default,
+{
+    #[inline]
+    fn default() -> AHashMap<K, V, S> {
+        AHashMap::with_hasher(Default::default())
+    }
+}

--- a/src/hash_set.rs
+++ b/src/hash_set.rs
@@ -1,0 +1,267 @@
+use std::collections::{hash_set, HashSet};
+use std::fmt::{self, Debug};
+use std::hash::{BuildHasher, Hash};
+use std::iter::FromIterator;
+use std::ops::{BitAnd, BitOr, BitXor, Deref, DerefMut, Sub};
+
+/// A [`HashSet`](std::collections::HashSet) using [`ABuildHasher`](crate::ABuildHasher) to hash the items.
+/// Requires the `std` feature to be enabled.
+#[derive(Clone)]
+pub struct AHashSet<T, S = crate::ABuildHasher>(HashSet<T, S>);
+
+impl<T, S> AHashSet<T, S>
+where
+    T: Hash + Eq,
+    S: BuildHasher + Default,
+{
+    pub fn new() -> Self {
+        AHashSet(HashSet::with_hasher(S::default()))
+    }
+
+    pub fn with_capacity(capacity: usize) -> Self {
+        AHashSet(HashSet::with_capacity_and_hasher(capacity, S::default()))
+    }
+}
+
+impl<T, S> AHashSet<T, S>
+where
+    T: Hash + Eq,
+    S: BuildHasher,
+{
+    pub fn with_hasher(hash_builder: S) -> Self {
+        AHashSet(HashSet::with_hasher(hash_builder))
+    }
+
+    pub fn with_capacity_and_hasher(capacity: usize, hash_builder: S) -> Self {
+        AHashSet(HashSet::with_capacity_and_hasher(capacity, hash_builder))
+    }
+}
+
+impl<T, S> Deref for AHashSet<T, S> {
+    type Target = HashSet<T, S>;
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<T, S> DerefMut for AHashSet<T, S> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+impl<T, S> PartialEq for AHashSet<T, S>
+where
+    T: Eq + Hash,
+    S: BuildHasher,
+{
+    fn eq(&self, other: &AHashSet<T, S>) -> bool {
+        self.0.eq(&other.0)
+    }
+}
+
+impl<T, S> Eq for AHashSet<T, S>
+where
+    T: Eq + Hash,
+    S: BuildHasher,
+{
+}
+
+impl<T, S> BitOr<&AHashSet<T, S>> for &AHashSet<T, S>
+where
+    T: Eq + Hash + Clone,
+    S: BuildHasher + Default,
+{
+    type Output = AHashSet<T, S>;
+
+    /// Returns the union of `self` and `rhs` as a new `AHashSet<T, S>`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use ahash::AHashSet;
+    ///
+    /// let a: AHashSet<_> = vec![1, 2, 3].into_iter().collect();
+    /// let b: AHashSet<_> = vec![3, 4, 5].into_iter().collect();
+    ///
+    /// let set = &a | &b;
+    ///
+    /// let mut i = 0;
+    /// let expected = [1, 2, 3, 4, 5];
+    /// for x in &set {
+    ///     assert!(expected.contains(x));
+    ///     i += 1;
+    /// }
+    /// assert_eq!(i, expected.len());
+    /// ```
+    fn bitor(self, rhs: &AHashSet<T, S>) -> AHashSet<T, S> {
+        AHashSet(self.0.bitor(&rhs.0))
+    }
+}
+
+impl<T, S> BitAnd<&AHashSet<T, S>> for &AHashSet<T, S>
+where
+    T: Eq + Hash + Clone,
+    S: BuildHasher + Default,
+{
+    type Output = AHashSet<T, S>;
+
+    /// Returns the intersection of `self` and `rhs` as a new `AHashSet<T, S>`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use ahash::AHashSet;
+    ///
+    /// let a: AHashSet<_> = vec![1, 2, 3].into_iter().collect();
+    /// let b: AHashSet<_> = vec![2, 3, 4].into_iter().collect();
+    ///
+    /// let set = &a & &b;
+    ///
+    /// let mut i = 0;
+    /// let expected = [2, 3];
+    /// for x in &set {
+    ///     assert!(expected.contains(x));
+    ///     i += 1;
+    /// }
+    /// assert_eq!(i, expected.len());
+    /// ```
+    fn bitand(self, rhs: &AHashSet<T, S>) -> AHashSet<T, S> {
+        AHashSet(self.0.bitand(&rhs.0))
+    }
+}
+
+impl<T, S> BitXor<&AHashSet<T, S>> for &AHashSet<T, S>
+where
+    T: Eq + Hash + Clone,
+    S: BuildHasher + Default,
+{
+    type Output = AHashSet<T, S>;
+
+    /// Returns the symmetric difference of `self` and `rhs` as a new `AHashSet<T, S>`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use ahash::AHashSet;
+    ///
+    /// let a: AHashSet<_> = vec![1, 2, 3].into_iter().collect();
+    /// let b: AHashSet<_> = vec![3, 4, 5].into_iter().collect();
+    ///
+    /// let set = &a ^ &b;
+    ///
+    /// let mut i = 0;
+    /// let expected = [1, 2, 4, 5];
+    /// for x in &set {
+    ///     assert!(expected.contains(x));
+    ///     i += 1;
+    /// }
+    /// assert_eq!(i, expected.len());
+    /// ```
+    fn bitxor(self, rhs: &AHashSet<T, S>) -> AHashSet<T, S> {
+        AHashSet(self.0.bitxor(&rhs.0))
+    }
+}
+
+impl<T, S> Sub<&AHashSet<T, S>> for &AHashSet<T, S>
+where
+    T: Eq + Hash + Clone,
+    S: BuildHasher + Default,
+{
+    type Output = AHashSet<T, S>;
+
+    /// Returns the difference of `self` and `rhs` as a new `AHashSet<T, S>`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use ahash::AHashSet;
+    ///
+    /// let a: AHashSet<_> = vec![1, 2, 3].into_iter().collect();
+    /// let b: AHashSet<_> = vec![3, 4, 5].into_iter().collect();
+    ///
+    /// let set = &a - &b;
+    ///
+    /// let mut i = 0;
+    /// let expected = [1, 2];
+    /// for x in &set {
+    ///     assert!(expected.contains(x));
+    ///     i += 1;
+    /// }
+    /// assert_eq!(i, expected.len());
+    /// ```
+    fn sub(self, rhs: &AHashSet<T, S>) -> AHashSet<T, S> {
+        AHashSet(self.0.sub(&rhs.0))
+    }
+}
+
+impl<T, S> Debug for AHashSet<T, S>
+where
+    T: Eq + Hash + Debug,
+    S: BuildHasher,
+{
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(fmt)
+    }
+}
+
+impl<T, S> FromIterator<T> for AHashSet<T, S>
+where
+    T: Eq + Hash,
+    S: BuildHasher + Default,
+{
+    #[inline]
+    fn from_iter<I: IntoIterator<Item = T>>(iter: I) -> AHashSet<T, S> {
+        AHashSet(HashSet::from_iter(iter))
+    }
+}
+
+impl<'a, T, S> IntoIterator for &'a AHashSet<T, S> {
+    type Item = (&'a T);
+    type IntoIter = hash_set::Iter<'a, T>;
+    fn into_iter(self) -> Self::IntoIter {
+        (&self.0).into_iter()
+    }
+}
+
+impl<T, S> IntoIterator for AHashSet<T, S> {
+    type Item = (T);
+    type IntoIter = hash_set::IntoIter<T>;
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.into_iter()
+    }
+}
+
+impl<T, S> Extend<T> for AHashSet<T, S>
+where
+    T: Eq + Hash,
+    S: BuildHasher,
+{
+    #[inline]
+    fn extend<I: IntoIterator<Item = T>>(&mut self, iter: I) {
+        self.0.extend(iter)
+    }
+}
+
+impl<'a, T, S> Extend<&'a T> for AHashSet<T, S>
+where
+    T: 'a + Eq + Hash + Copy,
+    S: BuildHasher,
+{
+    #[inline]
+    fn extend<I: IntoIterator<Item = &'a T>>(&mut self, iter: I) {
+        self.0.extend(iter)
+    }
+}
+
+impl<T, S> Default for AHashSet<T, S>
+where
+    T: Eq + Hash,
+    S: BuildHasher + Default,
+{
+    /// Creates an empty `AHashSet<T, S>` with the `Default` value for the hasher.
+    #[inline]
+    fn default() -> AHashSet<T, S> {
+        AHashSet(HashSet::default())
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,7 @@
 //!
 //! aHash uses the hardware AES instruction on x86 processors to provide a keyed hash function.
 //! It uses two rounds of AES per hash. So it should not be considered cryptographically secure.
-#![cfg_attr(not(test), no_std)]
+#![cfg_attr(all(not(test), not(feature = "std")), no_std)]
 //#![feature(core_intrinsics)]
 #[cfg(all(test, feature = "no_panic"))]
 extern crate no_panic;
@@ -23,6 +23,11 @@ mod aes_hash;
 mod fallback_hash;
 #[cfg(test)]
 mod hash_quality_test;
+
+#[cfg(feature = "std")]
+mod hash_map;
+#[cfg(feature = "std")]
+mod hash_set;
 
 #[cfg(feature = "compile-time-rng")]
 use const_random::const_random;
@@ -39,8 +44,10 @@ pub use crate::aes_hash::AHasher;
 #[cfg(not(all(any(target_arch = "x86", target_arch = "x86_64"), target_feature = "aes")))]
 pub use crate::fallback_hash::AHasher;
 
-/// A `HashMap` using `ABuildHasher` to hash the items.
-//pub type AHashMap<K, V> = HashMap<K, V, ABuildHasher>;
+#[cfg(feature = "std")]
+pub use crate::hash_map::AHashMap;
+#[cfg(feature = "std")]
+pub use crate::hash_set::AHashSet;
 
 ///This constant come from Kunth's prng
 const MULTIPLE: u64 = 6364136223846793005;


### PR DESCRIPTION
This adds `AHashMap` and `AHashSet`, which are thin newtype wrappers around `HashMap` and `HashSet` and use ahash instead of the default hasher.

Why add new types instead of simply making an alias with `pub type`? Unfortunately `{HashMap, HashSet}::{new, with_capacity}` (which are very widely used) are hardcoded to only be defined for `RandomState`, so with a type alias you would get an error if you'd do `AHashMap::new()`. (Which would make it harder to use this as a drop-in replacement.)

The trait `impl`s here are mostly copied from `std` with replaced bodies which proxy to the underlying `HashMap`/`HashSet` implementation.