### PR TITLE
Bump version, releasing `const_random` optional change

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ahash"
-version = "0.2.13"
+version = "0.2.14"
 authors = ["Tom Kaitchuck <Tom.Kaitchuck@gmail.com>"]
 license = "MIT OR Apache-2.0"
 description = "A non-cryprographic hash function using AES-NI for high performance"


### PR DESCRIPTION
This basically fixes issue https://github.com/tkaitchuck/aHash/issues/12
for our purposes, because we are supplying a seed drawn from RdRand.
It's really important to us to have bit-for-bit deterministic builds.

Please consider releasing this patch on crates.io. Thank you!