### PR TITLE
Fix build if `compile-time-rng` is disabled.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,6 @@
 #![allow(clippy::pedantic, clippy::cast_lossless, clippy::unreadable_literal)]
 
 #![cfg_attr(all(not(test), not(feature = "std")), no_std)]
-extern crate const_random;
 
 #[macro_use]
 mod convert;


### PR DESCRIPTION
The previous version always tried to include the `const_random` crate
even if the related feature was disabled. As this crates subscribed
into the 2018 edition the call should be obsolete and got deleted.