### PR TITLE
remove unecessary parentheses

### DIFF
--- a/src/fallback_hash.rs
+++ b/src/fallback_hash.rs
@@ -189,7 +189,7 @@ impl Hasher for AHasher {
     }
     #[inline]
     fn finish(&self) -> u64 {
-        (self.buffer ^ self.pad)
+        self.buffer ^ self.pad
     }
 }
 


### PR DESCRIPTION
Cliipy shows a warning
```
    |
192 |         (self.buffer ^ self.pad)
    |         ^^^^^^^^^^^^^^^^^^^^^^^^ help: remove these parentheses
    |
    = note: `#[warn(unused_parens)]` on by default
```