### PR TITLE
Add Debug impl to RandomState

### DIFF
--- a/src/random_state.rs
+++ b/src/random_state.rs
@@ -32,7 +32,7 @@ static SEED: AtomicUsize = AtomicUsize::new(INCREMENT as usize);
 /// [Hasher]: std::hash::Hasher
 /// [BuildHasher]: std::hash::BuildHasher
 /// [HashMap]: std::collections::HashMap
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct RandomState {
     pub(crate) k0: u64,
     pub(crate) k1: u64,

--- a/src/random_state.rs
+++ b/src/random_state.rs
@@ -1,6 +1,7 @@
 use crate::convert::Convert;
 use crate::operations::*;
 use crate::AHasher;
+use core::fmt;
 use core::hash::BuildHasher;
 use core::sync::atomic::AtomicUsize;
 use core::sync::atomic::Ordering;
@@ -32,12 +33,18 @@ static SEED: AtomicUsize = AtomicUsize::new(INCREMENT as usize);
 /// [Hasher]: std::hash::Hasher
 /// [BuildHasher]: std::hash::BuildHasher
 /// [HashMap]: std::collections::HashMap
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct RandomState {
     pub(crate) k0: u64,
     pub(crate) k1: u64,
     pub(crate) k2: u64,
     pub(crate) k3: u64,
+}
+
+impl fmt::Debug for RandomState {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.pad("RandomState { .. }")
+    }
 }
 
 impl RandomState {


### PR DESCRIPTION
Rust's standard `RandomState` type has a `Debug` impl whereas `ahash`'s `RandomState` does not causing some comfort problems for dependencies that try to be generic over their hash builders. This PR fixes this.

Link to Rust's `RandomState`: https://doc.rust-lang.org/std/collections/hash_map/struct.RandomState.html