### PR TITLE
Fix build with feature compile-time-rng

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,9 +30,6 @@ mod hash_set;
 mod random_state;
 mod specialize;
 
-#[cfg(all(not(feature = "std"), feature = "compile-time-rng"))]
-use const_random::const_random;
-
 #[cfg(all(any(target_arch = "x86", target_arch = "x86_64"), target_feature = "aes", not(miri)))]
 pub use crate::aes_hash::AHasher;
 

--- a/src/random_state.rs
+++ b/src/random_state.rs
@@ -1,5 +1,7 @@
 use crate::convert::Convert;
 use crate::{AHasher};
+#[cfg(all(not(feature = "std"), feature = "compile-time-rng"))]
+use const_random::const_random;
 use core::fmt;
 use core::hash::BuildHasher;
 use core::hash::Hasher;


### PR DESCRIPTION
Currently the build is broken with `--no-default-features --features compile-time-rng`