### PR TITLE
Adopt key mixing from fallback in AES variant

### DIFF
--- a/src/aes_hash.rs
+++ b/src/aes_hash.rs
@@ -4,6 +4,7 @@ use crate::operations::*;
 use crate::HasherExt;
 use core::hash::Hasher;
 use crate::RandomState;
+use crate::random_state::PI;
 
 /// A `Hasher` for hashing an arbitrary stream of bytes.
 ///
@@ -50,6 +51,9 @@ impl AHasher {
     /// ```
     #[inline]
     pub fn new_with_keys(key1: u128, key2: u128) -> Self {
+        let pi: [u128; 2] = PI.convert();
+        let key1: [u64; 2] = (key1 ^ pi[0]).convert();
+        let key2: [u64; 2] = (key2 ^ pi[1]).convert();
         Self {
             enc: key1,
             sum: key2,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -165,6 +165,7 @@ mod test {
     use crate::convert::Convert;
     use crate::*;
     use std::collections::HashMap;
+    use std::hash::Hash;
 
     #[test]
     fn test_default_builder() {
@@ -185,6 +186,45 @@ mod test {
         let input: &[u8] = b"dddddddd";
         let bytes: u64 = as_array!(input, 8).convert();
         assert_eq!(bytes, 0x6464646464646464);
+    }
+
+
+    #[test]
+    fn test_non_zero() {
+        let mut hasher1 = AHasher::new_with_keys(0, 0);
+        let mut hasher2 = AHasher::new_with_keys(0, 0);
+        "foo".hash(&mut hasher1);
+        "bar".hash(&mut hasher2);
+        assert_ne!(hasher1.finish(), 0);
+        assert_ne!(hasher2.finish(), 0);
+        assert_ne!(hasher1.finish(), hasher2.finish());
+
+        let mut hasher1 = AHasher::new_with_keys(0, 0);
+        let mut hasher2 = AHasher::new_with_keys(0, 0);
+        3_u64.hash(&mut hasher1);
+        4_u64.hash(&mut hasher2);
+        assert_ne!(hasher1.finish(), 0);
+        assert_ne!(hasher2.finish(), 0);
+        assert_ne!(hasher1.finish(), hasher2.finish());
+    }
+
+    #[test]
+    fn test_non_zero_specialized() {
+        let hasher1 = AHasher::new_with_keys(0, 0);
+        let hasher2 = AHasher::new_with_keys(0, 0);
+        let h1 = str::get_hash("foo", hasher1);
+        let h2 = str::get_hash("bar", hasher2);
+        assert_ne!(h1, 0);
+        assert_ne!(h2, 0);
+        assert_ne!(h1, h2);
+
+        let hasher1 = AHasher::new_with_keys(0, 0);
+        let hasher2 = AHasher::new_with_keys(0, 0);
+        let h1 = u64::get_hash(&3_u64, hasher1);
+        let h2 = u64::get_hash(&4_u64, hasher2);
+        assert_ne!(h1, 0);
+        assert_ne!(h2, 0);
+        assert_ne!(h1, h2);
     }
 
     #[test]


### PR DESCRIPTION
This should fix #70 
Code is similar to: https://github.com/tkaitchuck/aHash/blob/master/src/fallback_hash.rs#L35