### PR TITLE
Restore faster finish

### DIFF
--- a/src/fallback_hash.rs
+++ b/src/fallback_hash.rs
@@ -193,7 +193,7 @@ impl Hasher for AHasher {
     #[inline]
     fn finish(&self) -> u64 {
         let rot = (self.buffer & 63) as u32;
-        folded_multiply(self.buffer ^ self.pad, MULTIPLE).rotate_left(rot)
+        folded_multiply(self.buffer, self.pad).rotate_left(rot)
     }
 }
 


### PR DESCRIPTION
Now that https://github.com/tkaitchuck/aHash/pull/71 has been merged, https://github.com/tkaitchuck/aHash/commit/4edd74815be5b4542cd422e0c0542a6f27ec9c6d prevents the case of zero casing problems so https://github.com/tkaitchuck/aHash/commit/374729afd2fe2d3d1bd124b8e4aeeb547712453f is no longer needed.