### PR TITLE
Exclude smhasher from published crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ categories = ["algorithms", "data-structures", "no-std"]
 edition = "2018"
 readme = "README.md"
 build = "./build.rs"
+exclude = ["/smhasher"]
 
 [lib]
 name = "ahash"


### PR DESCRIPTION
Fuchsia would like to vendor aHash in order to support our Rust networking stack (see [this change](https://fuchsia-review.googlesource.com/c/fuchsia/+/483317)), but the `smhasher` directory doesn't have a clear license, so our open source policy forbids it. As long as that directory is excluded from the published crate, we will be able to vendor it.