### PR TITLE
Issue #76: Remove folded multiply on architectures where it optimizes poorly

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -30,4 +30,15 @@ fn main() {
     {
         println!("cargo:rustc-cfg=feature=\"runtime-rng\"");
     }
+    let arch = env::var("CARGO_CFG_TARGET_ARCH").expect("CARGO_CFG_TARGET_ARCH was not set");
+    if arch.eq_ignore_ascii_case("x86_64")
+        || arch.eq_ignore_ascii_case("aarch64")
+        || arch.eq_ignore_ascii_case("mips64")
+        || arch.eq_ignore_ascii_case("powerpc64")
+        || arch.eq_ignore_ascii_case("riscv64gc")
+        || arch.eq_ignore_ascii_case("s390x")
+    {
+        println!("cargo:rustc-cfg=feature=\"folded_multiply\"");
+    }
+
 }

--- a/src/fallback_hash.rs
+++ b/src/fallback_hash.rs
@@ -101,7 +101,10 @@ impl AHasher {
     #[inline(always)]
     #[cfg(not(feature = "folded_multiply"))]
     fn update(&mut self, new_data: u64) {
-        self.buffer = (new_data ^ self.buffer).wrapping_mul(MULTIPLE).rotate_left(ROT).wrapping_mul(MULTIPLE);
+        let d1 = (new_data ^ self.buffer).wrapping_mul(0xBF58476D1CE4E5B9);
+        let d2 = (new_data ^ self.pad).wrapping_mul(0x94D049BB133111EB);
+        self.pad = (self.pad ^ d1).rotate_left(10).wrapping_mul(MULTIPLE);
+        self.buffer = (self.buffer ^ d2).rotate_left(8).wrapping_mul(MULTIPLE);
     }
 
     /// Similar to the above this function performs an update using a "folded multiply".
@@ -208,8 +211,8 @@ impl Hasher for AHasher {
     #[inline]
     #[cfg(not(feature = "folded_multiply"))]
     fn finish(&self) -> u64 {
-        let rot = (self.buffer & 63) as u32;
-        (self.buffer ^ self.pad).wrapping_mul(MULTIPLE).rotate_left(ROT).wrapping_mul(MULTIPLE).rotate_left(rot)
+        let rot = (self.pad & 63) as u32;
+        (self.buffer ^ self.pad).rotate_left(24).wrapping_mul(MULTIPLE).rotate_left(rot)
     }
 }
 

--- a/src/fallback_hash.rs
+++ b/src/fallback_hash.rs
@@ -93,8 +93,15 @@ impl AHasher {
     /// attacker somehow knew part of (but not all) the contents of the buffer before hand,
     /// they would not be able to predict any of the bits in the buffer at the end.
     #[inline(always)]
+    #[cfg(not(miri))]
     fn update(&mut self, new_data: u64) {
         self.buffer = folded_multiply(new_data ^ self.buffer, MULTIPLE);
+    }
+
+    #[inline(always)]
+    #[cfg(miri)]
+    fn update(&mut self, new_data: u64) {
+        self.buffer = (new_data ^ self.buffer).wrapping_mul(MULTIPLE).rotate_left(ROT).wrapping_mul(MULTIPLE).rotate_left(ROT);
     }
 
     /// Similar to the above this function performs an update using a "folded multiply".
@@ -109,10 +116,19 @@ impl AHasher {
     /// can't be changed by the same set of input bits. To cancel this sequence with subsequent input would require
     /// knowing the keys.
     #[inline(always)]
+    #[cfg(not(miri))]
     fn large_update(&mut self, new_data: u128) {
         let block: [u64; 2] = new_data.convert();
         let combined = folded_multiply(block[0] ^ self.extra_keys[0], block[1] ^ self.extra_keys[1]);
         self.buffer = (self.buffer.wrapping_add(self.pad) ^ combined).rotate_left(ROT);
+    }
+
+    #[inline(always)]
+    #[cfg(miri)]
+    fn large_update(&mut self, new_data: u128) {
+        let block: [u64; 2] = new_data.convert();
+        self.update(block[0]);
+        self.update(block[1]);
     }
 
     #[inline]
@@ -183,9 +199,17 @@ impl Hasher for AHasher {
     }
 
     #[inline]
+    #[cfg(not(miri))]
     fn finish(&self) -> u64 {
         let rot = (self.buffer & 63) as u32;
         folded_multiply(self.buffer, self.pad).rotate_left(rot)
+    }
+
+    #[inline]
+    #[cfg(miri)]
+    fn finish(&self) -> u64 {
+        let rot = (self.buffer & 63) as u32;
+        (self.buffer ^ self.pad).wrapping_mul(MULTIPLE).rotate_left(ROT).wrapping_mul(MULTIPLE).rotate_left(rot)
     }
 }
 

--- a/src/fallback_hash.rs
+++ b/src/fallback_hash.rs
@@ -101,7 +101,7 @@ impl AHasher {
     #[inline(always)]
     #[cfg(not(feature = "folded_multiply"))]
     fn update(&mut self, new_data: u64) {
-        self.buffer = (new_data ^ self.buffer).wrapping_mul(MULTIPLE).rotate_left(ROT).wrapping_mul(MULTIPLE).rotate_left(ROT);
+        self.buffer = (new_data ^ self.buffer).wrapping_mul(MULTIPLE).rotate_left(ROT).wrapping_mul(MULTIPLE);
     }
 
     /// Similar to the above this function performs an update using a "folded multiply".


### PR DESCRIPTION
This fixes #76 by using the build script to identify architectures where folded multiply works and removing it on ones where it does not.