### PR TITLE
Use a runtime-rng feature flag instead of using OS detection

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,15 +22,18 @@ bench = true
 doc = true
 
 [features]
-default = ["std"]
+default = ["std", "runtime-rng"]
 
 # Enabling this will enable `AHashMap` and `AHashSet`.
 std = []
 
-# This is an alternitive to runtime key generation which does compile time key generation if getrandom is not available.
-# (If getrandom is available this does nothing.)
-# If this is on (and getrandom is off) it implies the produced binary will not be identical.
-# If this is disabled and gerrandom is unavailable constant keys are used.
+# Runtime random key generation using getrandom.
+runtime-rng = ["getrandom", "once_cell"]
+
+# This is an alternitive to runtime key generation which does compile time key generation if runtime-rng is not available.
+# (If runtime-rng is available this does nothing.)
+# If this is on (and runtime-rng is off) it implies the produced binary will not be identical.
+# If this is disabled and runtime-rng is unavailable constant keys are used.
 compile-time-rng = ["const-random"]
 
 [[bench]]
@@ -64,13 +67,9 @@ codegen-units = 1
 [build-dependencies]
 version_check = "0.9"
 
-[target.'cfg(any(target_os = "linux", target_os = "android", target_os = "windows", target_os = "macos", target_os = "ios", target_os = "freebsd", target_os = "openbsd", target_os = "netbsd", target_os = "dragonfly", target_os = "solaris", target_os = "illumos", target_os = "fuchsia", target_os = "redox", target_os = "cloudabi", target_os = "haiku", target_os = "vxworks", target_os = "emscripten", target_os = "wasi"))'.dependencies]
-once_cell = { version = "1.5.2", default-features = false, features = ["unstable", "alloc"] }
-getrandom = { version = "0.2.0" }
-const-random = { version = "0.1.12", optional = true }
-serde = { version = "1.0.117", optional = true }
-
-[target.'cfg(not(any(target_os = "linux", target_os = "android", target_os = "windows", target_os = "macos", target_os = "ios", target_os = "freebsd", target_os = "openbsd", target_os = "netbsd", target_os = "dragonfly", target_os = "solaris", target_os = "illumos", target_os = "fuchsia", target_os = "redox", target_os = "cloudabi", target_os = "haiku", target_os = "vxworks", target_os = "emscripten", target_os = "wasi")))'.dependencies]
+[dependencies]
+once_cell = { version = "1.5.2", default-features = false, features = ["unstable", "alloc"], optional = true }
+getrandom = { version = "0.2.0", optional = true }
 const-random = { version = "0.1.12", optional = true }
 serde = { version = "1.0.117", optional = true }
 

--- a/build.rs
+++ b/build.rs
@@ -9,27 +9,6 @@ fn main() {
             println!("cargo:rustc-cfg=feature=\"specialize\"");
         }
     }
-    let os = env::var("CARGO_CFG_TARGET_OS").expect("CARGO_CFG_TARGET_OS was not set");
-    if os.eq_ignore_ascii_case("linux")
-        || os.eq_ignore_ascii_case("android")
-        || os.eq_ignore_ascii_case("windows")
-        || os.eq_ignore_ascii_case("macos")
-        || os.eq_ignore_ascii_case("ios")
-        || os.eq_ignore_ascii_case("freebsd")
-        || os.eq_ignore_ascii_case("openbsd")
-        || os.eq_ignore_ascii_case("dragonfly")
-        || os.eq_ignore_ascii_case("solaris")
-        || os.eq_ignore_ascii_case("illumos")
-        || os.eq_ignore_ascii_case("fuchsia")
-        || os.eq_ignore_ascii_case("redox")
-        || os.eq_ignore_ascii_case("cloudabi")
-        || os.eq_ignore_ascii_case("haiku")
-        || os.eq_ignore_ascii_case("vxworks")
-        || os.eq_ignore_ascii_case("emscripten")
-        || os.eq_ignore_ascii_case("wasi")
-    {
-        println!("cargo:rustc-cfg=feature=\"runtime-rng\"");
-    }
     let arch = env::var("CARGO_CFG_TARGET_ARCH").expect("CARGO_CFG_TARGET_ARCH was not set");
     if arch.eq_ignore_ascii_case("x86_64")
         || arch.eq_ignore_ascii_case("aarch64")

--- a/src/random_state.rs
+++ b/src/random_state.rs
@@ -29,11 +29,6 @@ use core::sync::atomic::{AtomicUsize, Ordering};
 #[cfg(all(feature = "runtime-rng", not(all(feature = "compile-time-rng", test))))]
 use once_cell::race::OnceBox;
 
-#[cfg(all(any(target_arch = "x86", target_arch = "x86_64"), target_feature = "aes", not(miri)))]
-use crate::aes_hash::*;
-#[cfg(not(all(any(target_arch = "x86", target_arch = "x86_64"), target_feature = "aes", not(miri))))]
-use crate::fallback_hash::*;
-
 #[cfg(all(feature = "runtime-rng", not(all(feature = "compile-time-rng", test))))]
 static SEEDS: OnceBox<[[u64; 4]; 2]> = OnceBox::new();
 


### PR DESCRIPTION
The current OS detection is breaking my code which uses a custom linux target that doesn't have a libc.

`ahash` should have zero dependencies when build with `default-features = false`.