### PR TITLE
AArch64 implementation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,9 +24,6 @@ doc = true
 [features]
 default = ["std"]
 
-# Enabling this will enable AES-based hashing on ARM.
-stdsimd = []
-
 # Enabling this will enable `AHashMap` and `AHashSet`.
 std = []
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ doc = true
 default = ["std"]
 
 # Enabling this will enable AES-based hashing on ARM.
-nightly = []
+stdsimd = []
 
 # Enabling this will enable `AHashMap` and `AHashSet`.
 std = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,9 @@ doc = true
 [features]
 default = ["std"]
 
+# Enabling this will enable AES-based hashing on ARM.
+nightly = []
+
 # Enabling this will enable `AHashMap` and `AHashSet`.
 std = []
 

--- a/build.rs
+++ b/build.rs
@@ -7,7 +7,7 @@ fn main() {
     if let Some(channel) = version_check::Channel::read() {
         if channel.supports_features() {
             println!("cargo:rustc-cfg=feature=\"specialize\"");
-            println!("cargo:rustc-cfg=feature=\"nightly\"");
+            println!("cargo:rustc-cfg=feature=\"stdsimd\"");
         }
     }
     let os = env::var("CARGO_CFG_TARGET_OS").expect("CARGO_CFG_TARGET_OS was not set");

--- a/build.rs
+++ b/build.rs
@@ -7,6 +7,7 @@ fn main() {
     if let Some(channel) = version_check::Channel::read() {
         if channel.supports_features() {
             println!("cargo:rustc-cfg=feature=\"specialize\"");
+            println!("cargo:rustc-cfg=feature=\"nightly\"");
         }
     }
     let os = env::var("CARGO_CFG_TARGET_OS").expect("CARGO_CFG_TARGET_OS was not set");

--- a/src/hash_quality_test.rs
+++ b/src/hash_quality_test.rs
@@ -382,7 +382,7 @@ mod fallback_tests {
 ///Basic sanity tests of the cypto properties of aHash.
 #[cfg(any(
     all(any(target_arch = "x86", target_arch = "x86_64"), target_feature = "aes", not(miri)),
-    all(any(target_arch = "arm", target_arch = "aarch64"), target_feature = "crypto", not(miri))
+    all(any(target_arch = "arm", target_arch = "aarch64"), target_feature = "crypto", not(miri), feature = "nightly")
 ))]
 #[cfg(test)]
 mod aes_tests {

--- a/src/hash_quality_test.rs
+++ b/src/hash_quality_test.rs
@@ -380,7 +380,10 @@ mod fallback_tests {
 }
 
 ///Basic sanity tests of the cypto properties of aHash.
-#[cfg(all(any(target_arch = "x86", target_arch = "x86_64"), target_feature = "aes", not(miri)))]
+#[cfg(any(
+    all(any(target_arch = "x86", target_arch = "x86_64"), target_feature = "aes", not(miri)),
+    all(target_arch = "aarch64", target_feature = "crypto", not(miri))
+))]
 #[cfg(test)]
 mod aes_tests {
     use crate::aes_hash::*;

--- a/src/hash_quality_test.rs
+++ b/src/hash_quality_test.rs
@@ -382,7 +382,7 @@ mod fallback_tests {
 ///Basic sanity tests of the cypto properties of aHash.
 #[cfg(any(
     all(any(target_arch = "x86", target_arch = "x86_64"), target_feature = "aes", not(miri)),
-    all(target_arch = "aarch64", target_feature = "crypto", not(miri))
+    all(any(target_arch = "arm", target_arch = "aarch64"), target_feature = "crypto", not(miri))
 ))]
 #[cfg(test)]
 mod aes_tests {

--- a/src/hash_quality_test.rs
+++ b/src/hash_quality_test.rs
@@ -382,7 +382,7 @@ mod fallback_tests {
 ///Basic sanity tests of the cypto properties of aHash.
 #[cfg(any(
     all(any(target_arch = "x86", target_arch = "x86_64"), target_feature = "aes", not(miri)),
-    all(any(target_arch = "arm", target_arch = "aarch64"), target_feature = "crypto", not(miri), feature = "nightly")
+    all(any(target_arch = "arm", target_arch = "aarch64"), target_feature = "crypto", not(miri), feature = "stdsimd")
 ))]
 #[cfg(test)]
 mod aes_tests {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,7 +37,7 @@ mod convert;
 
 #[cfg(any(
     all(any(target_arch = "x86", target_arch = "x86_64"), target_feature = "aes", not(miri)),
-    all(target_arch = "aarch64", target_feature = "crypto", not(miri))
+    all(any(target_arch = "arm", target_arch = "aarch64"), target_feature = "crypto", not(miri))
 ))]
 mod aes_hash;
 mod fallback_hash;
@@ -54,13 +54,13 @@ mod specialize;
 
 #[cfg(any(
     all(any(target_arch = "x86", target_arch = "x86_64"), target_feature = "aes", not(miri)),
-    all(target_arch = "aarch64", target_feature = "crypto", not(miri))
+    all(any(target_arch = "arm", target_arch = "aarch64"), target_feature = "crypto", not(miri))
 ))]
 pub use crate::aes_hash::AHasher;
 
 #[cfg(not(any(
     all(any(target_arch = "x86", target_arch = "x86_64"), target_feature = "aes", not(miri)),
-    all(target_arch = "aarch64", target_feature = "crypto", not(miri))
+    all(any(target_arch = "arm", target_arch = "aarch64"), target_feature = "crypto", not(miri))
 )))]
 pub use crate::fallback_hash::AHasher;
 pub use crate::random_state::RandomState;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,14 +30,14 @@
 #![allow(clippy::pedantic, clippy::cast_lossless, clippy::unreadable_literal)]
 #![cfg_attr(all(not(test), not(feature = "std")), no_std)]
 #![cfg_attr(feature = "specialize", feature(min_specialization))]
-#![cfg_attr(feature = "nightly", feature(stdsimd))]
+#![cfg_attr(feature = "stdsimd", feature(stdsimd))]
 
 #[macro_use]
 mod convert;
 
 #[cfg(any(
     all(any(target_arch = "x86", target_arch = "x86_64"), target_feature = "aes", not(miri)),
-    all(any(target_arch = "arm", target_arch = "aarch64"), target_feature = "crypto", not(miri), feature = "nightly")
+    all(any(target_arch = "arm", target_arch = "aarch64"), target_feature = "crypto", not(miri), feature = "stdsimd")
 ))]
 mod aes_hash;
 mod fallback_hash;
@@ -54,13 +54,13 @@ mod specialize;
 
 #[cfg(any(
     all(any(target_arch = "x86", target_arch = "x86_64"), target_feature = "aes", not(miri)),
-    all(any(target_arch = "arm", target_arch = "aarch64"), target_feature = "crypto", not(miri), feature = "nightly")
+    all(any(target_arch = "arm", target_arch = "aarch64"), target_feature = "crypto", not(miri), feature = "stdsimd")
 ))]
 pub use crate::aes_hash::AHasher;
 
 #[cfg(not(any(
     all(any(target_arch = "x86", target_arch = "x86_64"), target_feature = "aes", not(miri)),
-    all(any(target_arch = "arm", target_arch = "aarch64"), target_feature = "crypto", not(miri), feature = "nightly")
+    all(any(target_arch = "arm", target_arch = "aarch64"), target_feature = "crypto", not(miri), feature = "stdsimd")
 )))]
 pub use crate::fallback_hash::AHasher;
 pub use crate::random_state::RandomState;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,14 +30,14 @@
 #![allow(clippy::pedantic, clippy::cast_lossless, clippy::unreadable_literal)]
 #![cfg_attr(all(not(test), not(feature = "std")), no_std)]
 #![cfg_attr(feature = "specialize", feature(min_specialization))]
-#![feature(stdsimd)]
+#![cfg_attr(feature = "nightly", feature(stdsimd))]
 
 #[macro_use]
 mod convert;
 
 #[cfg(any(
     all(any(target_arch = "x86", target_arch = "x86_64"), target_feature = "aes", not(miri)),
-    all(any(target_arch = "arm", target_arch = "aarch64"), target_feature = "crypto", not(miri))
+    all(any(target_arch = "arm", target_arch = "aarch64"), target_feature = "crypto", not(miri), feature = "nightly")
 ))]
 mod aes_hash;
 mod fallback_hash;
@@ -54,13 +54,13 @@ mod specialize;
 
 #[cfg(any(
     all(any(target_arch = "x86", target_arch = "x86_64"), target_feature = "aes", not(miri)),
-    all(any(target_arch = "arm", target_arch = "aarch64"), target_feature = "crypto", not(miri))
+    all(any(target_arch = "arm", target_arch = "aarch64"), target_feature = "crypto", not(miri), feature = "nightly")
 ))]
 pub use crate::aes_hash::AHasher;
 
 #[cfg(not(any(
     all(any(target_arch = "x86", target_arch = "x86_64"), target_feature = "aes", not(miri)),
-    all(any(target_arch = "arm", target_arch = "aarch64"), target_feature = "crypto", not(miri))
+    all(any(target_arch = "arm", target_arch = "aarch64"), target_feature = "crypto", not(miri), feature = "nightly")
 )))]
 pub use crate::fallback_hash::AHasher;
 pub use crate::random_state::RandomState;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,11 +30,15 @@
 #![allow(clippy::pedantic, clippy::cast_lossless, clippy::unreadable_literal)]
 #![cfg_attr(all(not(test), not(feature = "std")), no_std)]
 #![cfg_attr(feature = "specialize", feature(min_specialization))]
+#![feature(stdsimd)]
 
 #[macro_use]
 mod convert;
 
-#[cfg(all(any(target_arch = "x86", target_arch = "x86_64"), target_feature = "aes", not(miri)))]
+#[cfg(any(
+    all(any(target_arch = "x86", target_arch = "x86_64"), target_feature = "aes", not(miri)),
+    all(target_arch = "aarch64", target_feature = "crypto", not(miri))
+))]
 mod aes_hash;
 mod fallback_hash;
 #[cfg(test)]
@@ -48,10 +52,16 @@ mod operations;
 mod random_state;
 mod specialize;
 
-#[cfg(all(any(target_arch = "x86", target_arch = "x86_64"), target_feature = "aes", not(miri)))]
+#[cfg(any(
+    all(any(target_arch = "x86", target_arch = "x86_64"), target_feature = "aes", not(miri)),
+    all(target_arch = "aarch64", target_feature = "crypto", not(miri))
+))]
 pub use crate::aes_hash::AHasher;
 
-#[cfg(not(all(any(target_arch = "x86", target_arch = "x86_64"), target_feature = "aes", not(miri))))]
+#[cfg(not(any(
+    all(any(target_arch = "x86", target_arch = "x86_64"), target_feature = "aes", not(miri)),
+    all(target_arch = "aarch64", target_feature = "crypto", not(miri))
+)))]
 pub use crate::fallback_hash::AHasher;
 pub use crate::random_state::RandomState;
 

--- a/src/operations.rs
+++ b/src/operations.rs
@@ -100,6 +100,19 @@ pub(crate) fn aesenc(value: u128, xor: u128) -> u128 {
         transmute(_mm_aesenc_si128(value, transmute(xor)))
     }
 }
+
+#[cfg(all(target_arch = "aarch64", target_feature = "crypto", not(miri)))]
+#[allow(unused)]
+#[inline(always)]
+pub(crate) fn aesenc(value: u128, xor: u128) -> u128 {
+    use core::arch::aarch64::*;
+    use core::mem::transmute;
+    unsafe {
+        let value = transmute(value);
+        transmute(vaesmcq_u8(vaeseq_u8(value, transmute(xor))))
+    }
+}
+
 #[cfg(all(any(target_arch = "x86", target_arch = "x86_64"), target_feature = "aes", not(miri)))]
 #[allow(unused)]
 #[inline(always)]
@@ -112,6 +125,18 @@ pub(crate) fn aesdec(value: u128, xor: u128) -> u128 {
     unsafe {
         let value = transmute(value);
         transmute(_mm_aesdec_si128(value, transmute(xor)))
+    }
+}
+
+#[cfg(all(target_arch = "aarch64", target_feature = "crypto", not(miri)))]
+#[allow(unused)]
+#[inline(always)]
+pub(crate) fn aesdec(value: u128, xor: u128) -> u128 {
+    use core::arch::aarch64::*;
+    use core::mem::transmute;
+    unsafe {
+        let value = transmute(value);
+        transmute(vaesimcq_u8(vaesdq_u8(value, transmute(xor))))
     }
 }
 

--- a/src/operations.rs
+++ b/src/operations.rs
@@ -101,7 +101,7 @@ pub(crate) fn aesenc(value: u128, xor: u128) -> u128 {
     }
 }
 
-#[cfg(all(any(target_arch = "arm", target_arch = "aarch64"), target_feature = "crypto", not(miri)))]
+#[cfg(all(any(target_arch = "arm", target_arch = "aarch64"), target_feature = "crypto", not(miri), feature = "nightly"))]
 #[allow(unused)]
 #[inline(always)]
 pub(crate) fn aesenc(value: u128, xor: u128) -> u128 {
@@ -131,7 +131,7 @@ pub(crate) fn aesdec(value: u128, xor: u128) -> u128 {
     }
 }
 
-#[cfg(all(any(target_arch = "arm", target_arch = "aarch64"), target_feature = "crypto", not(miri)))]
+#[cfg(all(any(target_arch = "arm", target_arch = "aarch64"), target_feature = "crypto", not(miri), feature = "nightly"))]
 #[allow(unused)]
 #[inline(always)]
 pub(crate) fn aesdec(value: u128, xor: u128) -> u128 {

--- a/src/operations.rs
+++ b/src/operations.rs
@@ -101,7 +101,7 @@ pub(crate) fn aesenc(value: u128, xor: u128) -> u128 {
     }
 }
 
-#[cfg(all(any(target_arch = "arm", target_arch = "aarch64"), target_feature = "crypto", not(miri), feature = "nightly"))]
+#[cfg(all(any(target_arch = "arm", target_arch = "aarch64"), target_feature = "crypto", not(miri), feature = "stdsimd"))]
 #[allow(unused)]
 #[inline(always)]
 pub(crate) fn aesenc(value: u128, xor: u128) -> u128 {
@@ -131,7 +131,7 @@ pub(crate) fn aesdec(value: u128, xor: u128) -> u128 {
     }
 }
 
-#[cfg(all(any(target_arch = "arm", target_arch = "aarch64"), target_feature = "crypto", not(miri), feature = "nightly"))]
+#[cfg(all(any(target_arch = "arm", target_arch = "aarch64"), target_feature = "crypto", not(miri), feature = "stdsimd"))]
 #[allow(unused)]
 #[inline(always)]
 pub(crate) fn aesdec(value: u128, xor: u128) -> u128 {

--- a/src/operations.rs
+++ b/src/operations.rs
@@ -101,10 +101,13 @@ pub(crate) fn aesenc(value: u128, xor: u128) -> u128 {
     }
 }
 
-#[cfg(all(target_arch = "aarch64", target_feature = "crypto", not(miri)))]
+#[cfg(all(any(target_arch = "arm", target_arch = "aarch64"), target_feature = "crypto", not(miri)))]
 #[allow(unused)]
 #[inline(always)]
 pub(crate) fn aesenc(value: u128, xor: u128) -> u128 {
+    #[cfg(target_arch = "arm")]
+    use core::arch::arm::*;
+    #[cfg(target_arch = "aarch64")]
     use core::arch::aarch64::*;
     use core::mem::transmute;
     unsafe {
@@ -128,10 +131,13 @@ pub(crate) fn aesdec(value: u128, xor: u128) -> u128 {
     }
 }
 
-#[cfg(all(target_arch = "aarch64", target_feature = "crypto", not(miri)))]
+#[cfg(all(any(target_arch = "arm", target_arch = "aarch64"), target_feature = "crypto", not(miri)))]
 #[allow(unused)]
 #[inline(always)]
 pub(crate) fn aesdec(value: u128, xor: u128) -> u128 {
+    #[cfg(target_arch = "arm")]
+    use core::arch::arm::*;
+    #[cfg(target_arch = "aarch64")]
     use core::arch::aarch64::*;
     use core::mem::transmute;
     unsafe {

--- a/src/random_state.rs
+++ b/src/random_state.rs
@@ -5,13 +5,13 @@ use crate::BuildHasherExt;
 
 #[cfg(any(
     all(any(target_arch = "x86", target_arch = "x86_64"), target_feature = "aes", not(miri)),
-    all(any(target_arch = "arm", target_arch = "aarch64"), target_feature = "crypto", not(miri))
+    all(any(target_arch = "arm", target_arch = "aarch64"), target_feature = "crypto", not(miri), feature = "nightly")
 ))]
 pub use crate::aes_hash::*;
 
 #[cfg(not(any(
     all(any(target_arch = "x86", target_arch = "x86_64"), target_feature = "aes", not(miri)),
-    all(any(target_arch = "arm", target_arch = "aarch64"), target_feature = "crypto", not(miri))
+    all(any(target_arch = "arm", target_arch = "aarch64"), target_feature = "crypto", not(miri), feature = "nightly")
 )))]
 pub use crate::fallback_hash::*;
 
@@ -37,12 +37,12 @@ use once_cell::race::OnceBox;
 
 #[cfg(any(
     all(any(target_arch = "x86", target_arch = "x86_64"), target_feature = "aes", not(miri)),
-    all(any(target_arch = "arm", target_arch = "aarch64"), target_feature = "crypto", not(miri))
+    all(any(target_arch = "arm", target_arch = "aarch64"), target_feature = "crypto", not(miri), feature = "nightly")
 ))]
 use crate::aes_hash::*;
 #[cfg(not(any(
     all(any(target_arch = "x86", target_arch = "x86_64"), target_feature = "aes", not(miri)),
-    all(any(target_arch = "arm", target_arch = "aarch64"), target_feature = "crypto", not(miri))
+    all(any(target_arch = "arm", target_arch = "aarch64"), target_feature = "crypto", not(miri), feature = "nightly")
 )))]
 use crate::fallback_hash::*;
 

--- a/src/random_state.rs
+++ b/src/random_state.rs
@@ -5,13 +5,13 @@ use crate::BuildHasherExt;
 
 #[cfg(any(
     all(any(target_arch = "x86", target_arch = "x86_64"), target_feature = "aes", not(miri)),
-    all(any(target_arch = "arm", target_arch = "aarch64"), target_feature = "crypto", not(miri), feature = "nightly")
+    all(any(target_arch = "arm", target_arch = "aarch64"), target_feature = "crypto", not(miri), feature = "stdsimd")
 ))]
 pub use crate::aes_hash::*;
 
 #[cfg(not(any(
     all(any(target_arch = "x86", target_arch = "x86_64"), target_feature = "aes", not(miri)),
-    all(any(target_arch = "arm", target_arch = "aarch64"), target_feature = "crypto", not(miri), feature = "nightly")
+    all(any(target_arch = "arm", target_arch = "aarch64"), target_feature = "crypto", not(miri), feature = "stdsimd")
 )))]
 pub use crate::fallback_hash::*;
 
@@ -37,12 +37,12 @@ use once_cell::race::OnceBox;
 
 #[cfg(any(
     all(any(target_arch = "x86", target_arch = "x86_64"), target_feature = "aes", not(miri)),
-    all(any(target_arch = "arm", target_arch = "aarch64"), target_feature = "crypto", not(miri), feature = "nightly")
+    all(any(target_arch = "arm", target_arch = "aarch64"), target_feature = "crypto", not(miri), feature = "stdsimd")
 ))]
 use crate::aes_hash::*;
 #[cfg(not(any(
     all(any(target_arch = "x86", target_arch = "x86_64"), target_feature = "aes", not(miri)),
-    all(any(target_arch = "arm", target_arch = "aarch64"), target_feature = "crypto", not(miri), feature = "nightly")
+    all(any(target_arch = "arm", target_arch = "aarch64"), target_feature = "crypto", not(miri), feature = "stdsimd")
 )))]
 use crate::fallback_hash::*;
 

--- a/src/random_state.rs
+++ b/src/random_state.rs
@@ -3,10 +3,16 @@ use crate::convert::Convert;
 #[cfg(feature = "specialize")]
 use crate::BuildHasherExt;
 
-#[cfg(all(any(target_arch = "x86", target_arch = "x86_64"), target_feature = "aes", not(miri)))]
+#[cfg(any(
+    all(any(target_arch = "x86", target_arch = "x86_64"), target_feature = "aes", not(miri)),
+    all(target_arch = "aarch64", target_feature = "crypto", not(miri))
+))]
 pub use crate::aes_hash::*;
 
-#[cfg(not(all(any(target_arch = "x86", target_arch = "x86_64"), target_feature = "aes", not(miri))))]
+#[cfg(not(any(
+    all(any(target_arch = "x86", target_arch = "x86_64"), target_feature = "aes", not(miri)),
+    all(target_arch = "aarch64", target_feature = "crypto", not(miri))
+)))]
 pub use crate::fallback_hash::*;
 
 #[cfg(all(feature = "compile-time-rng", any(not(feature = "runtime-rng"), test)))]
@@ -29,9 +35,15 @@ use core::sync::atomic::{AtomicUsize, Ordering};
 #[cfg(all(feature = "runtime-rng", not(all(feature = "compile-time-rng", test))))]
 use once_cell::race::OnceBox;
 
-#[cfg(all(any(target_arch = "x86", target_arch = "x86_64"), target_feature = "aes", not(miri)))]
+#[cfg(any(
+    all(any(target_arch = "x86", target_arch = "x86_64"), target_feature = "aes", not(miri)),
+    all(target_arch = "aarch64", target_feature = "crypto", not(miri))
+))]
 use crate::aes_hash::*;
-#[cfg(not(all(any(target_arch = "x86", target_arch = "x86_64"), target_feature = "aes", not(miri))))]
+#[cfg(not(any(
+    all(any(target_arch = "x86", target_arch = "x86_64"), target_feature = "aes", not(miri)),
+    all(target_arch = "aarch64", target_feature = "crypto", not(miri))
+)))]
 use crate::fallback_hash::*;
 
 #[cfg(all(feature = "runtime-rng", not(all(feature = "compile-time-rng", test))))]

--- a/src/random_state.rs
+++ b/src/random_state.rs
@@ -5,13 +5,13 @@ use crate::BuildHasherExt;
 
 #[cfg(any(
     all(any(target_arch = "x86", target_arch = "x86_64"), target_feature = "aes", not(miri)),
-    all(target_arch = "aarch64", target_feature = "crypto", not(miri))
+    all(any(target_arch = "arm", target_arch = "aarch64"), target_feature = "crypto", not(miri))
 ))]
 pub use crate::aes_hash::*;
 
 #[cfg(not(any(
     all(any(target_arch = "x86", target_arch = "x86_64"), target_feature = "aes", not(miri)),
-    all(target_arch = "aarch64", target_feature = "crypto", not(miri))
+    all(any(target_arch = "arm", target_arch = "aarch64"), target_feature = "crypto", not(miri))
 )))]
 pub use crate::fallback_hash::*;
 
@@ -37,12 +37,12 @@ use once_cell::race::OnceBox;
 
 #[cfg(any(
     all(any(target_arch = "x86", target_arch = "x86_64"), target_feature = "aes", not(miri)),
-    all(target_arch = "aarch64", target_feature = "crypto", not(miri))
+    all(any(target_arch = "arm", target_arch = "aarch64"), target_feature = "crypto", not(miri))
 ))]
 use crate::aes_hash::*;
 #[cfg(not(any(
     all(any(target_arch = "x86", target_arch = "x86_64"), target_feature = "aes", not(miri)),
-    all(target_arch = "aarch64", target_feature = "crypto", not(miri))
+    all(any(target_arch = "arm", target_arch = "aarch64"), target_feature = "crypto", not(miri))
 )))]
 use crate::fallback_hash::*;
 

--- a/tests/bench.rs
+++ b/tests/bench.rs
@@ -6,7 +6,7 @@ use std::hash::{Hash, Hasher};
 
 #[cfg(any(
     all(any(target_arch = "x86", target_arch = "x86_64"), target_feature = "aes", not(miri)),
-    all(any(target_arch = "arm", target_arch = "aarch64"), target_feature = "crypto", not(miri), feature = "nightly")
+    all(any(target_arch = "arm", target_arch = "aarch64"), target_feature = "crypto", not(miri), feature = "stdsimd")
 ))]
 fn aeshash<H: Hash>(b: &H) -> u64 {
     let build_hasher = RandomState::with_seeds(1, 2, 3, 4);
@@ -14,7 +14,7 @@ fn aeshash<H: Hash>(b: &H) -> u64 {
 }
 #[cfg(not(any(
     all(any(target_arch = "x86", target_arch = "x86_64"), target_feature = "aes", not(miri)),
-    all(any(target_arch = "arm", target_arch = "aarch64"), target_feature = "crypto", not(miri), feature = "nightly")
+    all(any(target_arch = "arm", target_arch = "aarch64"), target_feature = "crypto", not(miri), feature = "stdsimd")
 )))]
 fn aeshash<H: Hash>(_b: &H) -> u64 {
     panic!("aes must be enabled")
@@ -22,7 +22,7 @@ fn aeshash<H: Hash>(_b: &H) -> u64 {
 
 #[cfg(not(any(
     all(any(target_arch = "x86", target_arch = "x86_64"), target_feature = "aes", not(miri)),
-    all(any(target_arch = "arm", target_arch = "aarch64"), target_feature = "crypto", not(miri), feature = "nightly")
+    all(any(target_arch = "arm", target_arch = "aarch64"), target_feature = "crypto", not(miri), feature = "stdsimd")
 )))]
 fn fallbackhash<H: Hash>(b: &H) -> u64 {
     let build_hasher = RandomState::with_seeds(1, 2, 3, 4);
@@ -30,7 +30,7 @@ fn fallbackhash<H: Hash>(b: &H) -> u64 {
 }
 #[cfg(any(
     all(any(target_arch = "x86", target_arch = "x86_64"), target_feature = "aes", not(miri)),
-    all(any(target_arch = "arm", target_arch = "aarch64"), target_feature = "crypto", not(miri), feature = "nightly")
+    all(any(target_arch = "arm", target_arch = "aarch64"), target_feature = "crypto", not(miri), feature = "stdsimd")
 ))]
 fn fallbackhash<H: Hash>(_b: &H) -> u64 {
     panic!("aes must be disabled")

--- a/tests/bench.rs
+++ b/tests/bench.rs
@@ -4,22 +4,34 @@ use fxhash::FxHasher;
 use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};
 
-#[cfg(all(any(target_arch = "x86", target_arch = "x86_64"), target_feature = "aes"))]
+#[cfg(any(
+    all(any(target_arch = "x86", target_arch = "x86_64"), target_feature = "aes", not(miri)),
+    all(target_arch = "aarch64", target_feature = "crypto", not(miri))
+))]
 fn aeshash<H: Hash>(b: &H) -> u64 {
     let build_hasher = RandomState::with_seeds(1, 2, 3, 4);
     H::get_hash(b, &build_hasher)
 }
-#[cfg(not(all(any(target_arch = "x86", target_arch = "x86_64"), target_feature = "aes")))]
+#[cfg(not(any(
+    all(any(target_arch = "x86", target_arch = "x86_64"), target_feature = "aes", not(miri)),
+    all(target_arch = "aarch64", target_feature = "crypto", not(miri))
+)))]
 fn aeshash<H: Hash>(_b: &H) -> u64 {
     panic!("aes must be enabled")
 }
 
-#[cfg(not(all(any(target_arch = "x86", target_arch = "x86_64"), target_feature = "aes")))]
+#[cfg(not(any(
+    all(any(target_arch = "x86", target_arch = "x86_64"), target_feature = "aes", not(miri)),
+    all(target_arch = "aarch64", target_feature = "crypto", not(miri))
+)))]
 fn fallbackhash<H: Hash>(b: &H) -> u64 {
     let build_hasher = RandomState::with_seeds(1, 2, 3, 4);
     H::get_hash(b, &build_hasher)
 }
-#[cfg(all(any(target_arch = "x86", target_arch = "x86_64"), target_feature = "aes"))]
+#[cfg(any(
+    all(any(target_arch = "x86", target_arch = "x86_64"), target_feature = "aes", not(miri)),
+    all(target_arch = "aarch64", target_feature = "crypto", not(miri))
+))]
 fn fallbackhash<H: Hash>(_b: &H) -> u64 {
     panic!("aes must be disabled")
 }

--- a/tests/bench.rs
+++ b/tests/bench.rs
@@ -6,7 +6,7 @@ use std::hash::{Hash, Hasher};
 
 #[cfg(any(
     all(any(target_arch = "x86", target_arch = "x86_64"), target_feature = "aes", not(miri)),
-    all(target_arch = "aarch64", target_feature = "crypto", not(miri))
+    all(any(target_arch = "arm", target_arch = "aarch64"), target_feature = "crypto", not(miri))
 ))]
 fn aeshash<H: Hash>(b: &H) -> u64 {
     let build_hasher = RandomState::with_seeds(1, 2, 3, 4);
@@ -14,7 +14,7 @@ fn aeshash<H: Hash>(b: &H) -> u64 {
 }
 #[cfg(not(any(
     all(any(target_arch = "x86", target_arch = "x86_64"), target_feature = "aes", not(miri)),
-    all(target_arch = "aarch64", target_feature = "crypto", not(miri))
+    all(any(target_arch = "arm", target_arch = "aarch64"), target_feature = "crypto", not(miri))
 )))]
 fn aeshash<H: Hash>(_b: &H) -> u64 {
     panic!("aes must be enabled")
@@ -22,7 +22,7 @@ fn aeshash<H: Hash>(_b: &H) -> u64 {
 
 #[cfg(not(any(
     all(any(target_arch = "x86", target_arch = "x86_64"), target_feature = "aes", not(miri)),
-    all(target_arch = "aarch64", target_feature = "crypto", not(miri))
+    all(any(target_arch = "arm", target_arch = "aarch64"), target_feature = "crypto", not(miri))
 )))]
 fn fallbackhash<H: Hash>(b: &H) -> u64 {
     let build_hasher = RandomState::with_seeds(1, 2, 3, 4);
@@ -30,7 +30,7 @@ fn fallbackhash<H: Hash>(b: &H) -> u64 {
 }
 #[cfg(any(
     all(any(target_arch = "x86", target_arch = "x86_64"), target_feature = "aes", not(miri)),
-    all(target_arch = "aarch64", target_feature = "crypto", not(miri))
+    all(any(target_arch = "arm", target_arch = "aarch64"), target_feature = "crypto", not(miri))
 ))]
 fn fallbackhash<H: Hash>(_b: &H) -> u64 {
     panic!("aes must be disabled")

--- a/tests/bench.rs
+++ b/tests/bench.rs
@@ -6,7 +6,7 @@ use std::hash::{Hash, Hasher};
 
 #[cfg(any(
     all(any(target_arch = "x86", target_arch = "x86_64"), target_feature = "aes", not(miri)),
-    all(any(target_arch = "arm", target_arch = "aarch64"), target_feature = "crypto", not(miri))
+    all(any(target_arch = "arm", target_arch = "aarch64"), target_feature = "crypto", not(miri), feature = "nightly")
 ))]
 fn aeshash<H: Hash>(b: &H) -> u64 {
     let build_hasher = RandomState::with_seeds(1, 2, 3, 4);
@@ -14,7 +14,7 @@ fn aeshash<H: Hash>(b: &H) -> u64 {
 }
 #[cfg(not(any(
     all(any(target_arch = "x86", target_arch = "x86_64"), target_feature = "aes", not(miri)),
-    all(any(target_arch = "arm", target_arch = "aarch64"), target_feature = "crypto", not(miri))
+    all(any(target_arch = "arm", target_arch = "aarch64"), target_feature = "crypto", not(miri), feature = "nightly")
 )))]
 fn aeshash<H: Hash>(_b: &H) -> u64 {
     panic!("aes must be enabled")
@@ -22,7 +22,7 @@ fn aeshash<H: Hash>(_b: &H) -> u64 {
 
 #[cfg(not(any(
     all(any(target_arch = "x86", target_arch = "x86_64"), target_feature = "aes", not(miri)),
-    all(any(target_arch = "arm", target_arch = "aarch64"), target_feature = "crypto", not(miri))
+    all(any(target_arch = "arm", target_arch = "aarch64"), target_feature = "crypto", not(miri), feature = "nightly")
 )))]
 fn fallbackhash<H: Hash>(b: &H) -> u64 {
     let build_hasher = RandomState::with_seeds(1, 2, 3, 4);
@@ -30,7 +30,7 @@ fn fallbackhash<H: Hash>(b: &H) -> u64 {
 }
 #[cfg(any(
     all(any(target_arch = "x86", target_arch = "x86_64"), target_feature = "aes", not(miri)),
-    all(any(target_arch = "arm", target_arch = "aarch64"), target_feature = "crypto", not(miri))
+    all(any(target_arch = "arm", target_arch = "aarch64"), target_feature = "crypto", not(miri), feature = "nightly")
 ))]
 fn fallbackhash<H: Hash>(_b: &H) -> u64 {
     panic!("aes must be disabled")


### PR DESCRIPTION
Fixes #84. Not particularly polished.

Passes all tests:
```
running 42 tests
test fallback_hash::tests::test_conversion ... ok
test aes_hash::tests::test_conversion ... ok
test aes_hash::tests::test_sanity ... ok
test fallback_hash::tests::test_hash ... ok
test hash_quality_test::aes_tests::aes_all_bytes_matter ... ok
test aes_hash::tests::test_hash ... ok
test hash_quality_test::aes_tests::aes_finish_is_consistant ... ok
test hash_map::test::test_borrow ... ok
test hash_quality_test::aes_tests::aes_input_affect_every_byte ... ok
test hash_quality_test::aes_tests::aes_keys_change_output ... ok
test hash_quality_test::aes_tests::aes_keys_affect_every_byte ... ok
test hash_quality_test::aes_tests::aes_single_key_bit_flip ... ok
test hash_quality_test::aes_tests::test_single_bit_in_byte ... ok
test hash_quality_test::fallback_tests::fallback_all_bytes_matter ... ok
test hash_quality_test::fallback_tests::fallback_finish_is_consistant ... ok
test hash_quality_test::fallback_tests::fallback_input_affect_every_byte ... ok
test hash_quality_test::fallback_tests::fallback_keys_affect_every_byte ... ok
test hash_quality_test::fallback_tests::fallback_keys_change_output ... ok
test hash_quality_test::aes_tests::aes_single_bit_flip ... ok
test hash_quality_test::aes_tests::aes_test_no_pair_collisions ... ok
test hash_quality_test::fallback_tests::fallback_single_key_bit_flip ... ok
test hash_quality_test::fallback_tests::fallback_single_bit_flip ... ok
test operations::test::test_shuffle_contains_each_value ... ok
test hash_quality_test::fallback_tests::fallback_test_no_pair_collisions ... ok
test hash_quality_test::aes_tests::aes_padding_doesnot_collide ... ok
test operations::test::test_shuffle_moves_high_bits ... ok
test operations::test::test_shuffle_moves_every_value ... ok
test random_state::test::test_unique ... ok
test random_state::test::test_not_pi ... ok
test random_state::test::test_with_seeds_const ... ok
test specialize::test::test_input_processed ... ok
test specialize::test::test_ref_independent ... ok
test specialize::test::test_specialized_invoked ... ok
test test::test_ahasher_construction ... ok
test test::test_builder ... ok
test test::test_default_builder ... ok
test test::test_conversion ... ok
test hash_quality_test::fallback_tests::fallback_padding_doesnot_collide ... ok
test test::test_non_zero ... ok
test test::test_non_zero_specialized ... ok
test hash_quality_test::fallback_tests::fallback_test_no_full_collisions ... ok
test hash_quality_test::aes_tests::ase_test_no_full_collisions ... ok

test result: ok. 42 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 3.04s
```

Benchmark (Qualcomm Snapdragon 730G):
```
aeshash/u8              time:   [3.2561 ns 3.2563 ns 3.2564 ns]                        
Found 9 outliers among 100 measurements (9.00%)
  1 (1.00%) low severe
  1 (1.00%) low mild
  3 (3.00%) high mild
  4 (4.00%) high severe
aeshash/u16             time:   [3.2557 ns 3.2560 ns 3.2564 ns]                         
Found 12 outliers among 100 measurements (12.00%)
  2 (2.00%) low severe
  1 (1.00%) low mild
  3 (3.00%) high mild
  6 (6.00%) high severe
aeshash/u32             time:   [3.2558 ns 3.2560 ns 3.2562 ns]                         
Found 11 outliers among 100 measurements (11.00%)
  2 (2.00%) low severe
  3 (3.00%) low mild
  2 (2.00%) high mild
  4 (4.00%) high severe
aeshash/u64             time:   [3.2557 ns 3.2571 ns 3.2599 ns]                         
Found 9 outliers among 100 measurements (9.00%)
  1 (1.00%) low severe
  1 (1.00%) low mild
  4 (4.00%) high mild
  3 (3.00%) high severe
aeshash/u128            time:   [940.45 ps 944.50 ps 948.68 ps]                          
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high severe
aeshash/string          time:   [199.92 ns 200.29 ns 200.65 ns]                           
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild
```

... as compared to fallback implementation on 730G:
```
fallback/u8             time:   [3.2571 ns 3.2574 ns 3.2576 ns]                         
Found 11 outliers among 100 measurements (11.00%)
  2 (2.00%) low severe
  1 (1.00%) low mild
  5 (5.00%) high mild
  3 (3.00%) high severe
fallback/u16            time:   [3.2569 ns 3.2570 ns 3.2572 ns]                          
Found 10 outliers among 100 measurements (10.00%)
  2 (2.00%) low severe
  2 (2.00%) low mild
  3 (3.00%) high mild
  3 (3.00%) high severe
fallback/u32            time:   [3.2572 ns 3.2575 ns 3.2577 ns]                          
Found 9 outliers among 100 measurements (9.00%)
  1 (1.00%) low severe
  2 (2.00%) low mild
  4 (4.00%) high mild
  2 (2.00%) high severe
fallback/u64            time:   [3.2573 ns 3.2591 ns 3.2630 ns]                          
Found 11 outliers among 100 measurements (11.00%)
  2 (2.00%) low severe
  2 (2.00%) low mild
  2 (2.00%) high mild
  5 (5.00%) high severe
fallback/u128           time:   [913.23 ps 914.34 ps 915.56 ps]                           
Found 6 outliers among 100 measurements (6.00%)
  3 (3.00%) high mild
  3 (3.00%) high severe
fallback/string         time:   [346.18 ns 346.20 ns 346.22 ns]                            
Found 9 outliers among 100 measurements (9.00%)
  4 (4.00%) low severe
  3 (3.00%) high mild
  2 (2.00%) high severe
```

(main timing difference appears in string benchmark)