### PR TITLE
restore MSRV to 1.43.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,6 @@ edition = "2018"
 readme = "README.md"
 build = "./build.rs"
 exclude = ["/smhasher", "/benchmark_tools"]
-resolver = "2"
 
 [lib]
 name = "ahash"


### PR DESCRIPTION
closes #99 

before:
```
$ cargo msrv --bisect
Determining the Minimum Supported Rust Version (MSRV) for toolchain x86_64-apple-darwin
Using check command cargo check --all
   Finished The MSRV is: 1.51.0
```

after:
```
$ cargo msrv --bisect
Determining the Minimum Supported Rust Version (MSRV) for toolchain x86_64-apple-darwin
Using check command cargo check --all
   Finished The MSRV is: 1.43.1
```