### PR TITLE
Add type-alias feature to make it more of a drop in replacement for std Hash[Set|Map]

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,9 @@ default = ["std"]
 
 # Enabling this will enable `AHashMap` and `AHashSet`.
 std = []
+# Enabling this will use type aliases instead for new types for `AHashMap` and `AHashSet` 
+# Note that this is mutually exclusive to the "std" feature
+type-alias = []
 
 # This is an alternitive to runtime key generation which does compile time key generation if getrandom is not available.
 # (If getrandom is available this does nothing.)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,9 +26,6 @@ default = ["std"]
 
 # Enabling this will enable `AHashMap` and `AHashSet`.
 std = []
-# Enabling this will use type aliases instead for new types for `AHashMap` and `AHashSet` 
-# Note that this is mutually exclusive to the "std" feature
-type-alias = []
 
 # This is an alternitive to runtime key generation which does compile time key generation if getrandom is not available.
 # (If getrandom is available this does nothing.)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,11 +62,11 @@ mod hash_quality_test;
 #[cfg(feature = "std")]
 /// [Hasher]: std::hash::Hasher
 /// [HashMap]: std::collections::HashMap
-/// Type alias for [HashMap]<K, V, std::hash::BuildHasherDefault<AHasher>>
-pub type HashMap<K, V> = std::collections::HashMap<K, V, std::hash::BuildHasherDefault<AHasher>>;
+/// Type alias for [HashMap]<K, V, ahash::RandomState>
+pub type HashMap<K, V> = std::collections::HashMap<K, V, crate::RandomState>;
 #[cfg(feature = "std")]
-/// Type alias for [HashSet]<K, std::hash::BuildHasherDefault<AHasher>>
-pub type HashSet<K> = std::collections::HashSet<K, std::hash::BuildHasherDefault<AHasher>>;
+/// Type alias for [HashSet]<K, ahash::RandomState>
+pub type HashSet<K> = std::collections::HashSet<K, crate::RandomState>;
 
 #[cfg(feature = "std")]
 mod hash_map;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,18 +17,28 @@
 //! let mut map: HashMap<i32, i32, RandomState> = HashMap::default();
 //! map.insert(12, 34);
 //! ```
-//! For convinence wrappers called `AHashMap` and `AHashSet` are also provided.
-//! These to the same thing with slightly less typing.
+//! For convinence both new type wrappers and type aliases. The new type wrappers are called called `AHashMap` and `AHashSet`. These do the same thing with slightly less typing.
+//! The type aliases are called `ahash::HashMap`, `ahash::HashSet` are also provided and alias the
+//! std::[HashMap] and std::[HashSet]. Why are there two options? The wrappers are convenient but
+//! prevent you from using it as a swap in replacement for the normal std collections.
+//! 
 //! ```ignore
 //! use ahash::AHashMap;
 //!
 //! let mut map: AHashMap<i32, i32> = AHashMap::with_capacity(4);
 //! map.insert(12, 34);
 //! map.insert(56, 78);
+//! // There are also type aliases provieded together with some extension traits to make
+//! // it more of a drop in replacement for the std::HashMap/HashSet
+//! use ahash::{HashMapExt, HashSetExt}; // Used to get with_capacity()
+//! let mut map = ahash::HashMap::with_capacity(10);
+//! map.insert(12, 34);
+//! let mut set = ahash::HashSet::with_capacity(10);
+//! set.insert(10);
 //! ```
 #![deny(clippy::correctness, clippy::complexity, clippy::perf)]
 #![allow(clippy::pedantic, clippy::cast_lossless, clippy::unreadable_literal)]
-#![cfg_attr(all(not(test), not(feature = "std"), not(feature = "type-alias")), no_std)]
+#![cfg_attr(all(not(test), not(feature = "std")), no_std)]
 #![cfg_attr(feature = "specialize", feature(min_specialization))]
 #![cfg_attr(feature = "stdsimd", feature(stdsimd))]
 
@@ -37,26 +47,30 @@ mod convert;
 
 #[cfg(any(
     all(any(target_arch = "x86", target_arch = "x86_64"), target_feature = "aes", not(miri)),
-    all(any(target_arch = "arm", target_arch = "aarch64"), target_feature = "crypto", not(miri), feature = "stdsimd")
+    all(
+        any(target_arch = "arm", target_arch = "aarch64"),
+        target_feature = "crypto",
+        not(miri),
+        feature = "stdsimd"
+    )
 ))]
 mod aes_hash;
 mod fallback_hash;
 #[cfg(test)]
 mod hash_quality_test;
 
-// Ensure mutal exlusive features
-#[cfg(all(feature = "std", feature = "type-alias"))]
-compile_error!("Feature \"std\" and \"type-alias\" are mutually exlusive");
+#[cfg(feature = "std")]
+/// [Hasher]: std::hash::Hasher
+/// [HashMap]: std::collections::HashMap
+/// Type alias for [HashMap]<K, V, std::hash::BuildHasherDefault<AHasher>>
+pub type HashMap<K, V> = std::collections::HashMap<K, V, std::hash::BuildHasherDefault<AHasher>>;
+#[cfg(feature = "std")]
+/// Type alias for [HashSet]<K, std::hash::BuildHasherDefault<AHasher>>
+pub type HashSet<K> = std::collections::HashSet<K, std::hash::BuildHasherDefault<AHasher>>;
 
-#[cfg(all(feature = "type-alias", not(feature = "std")))]
-pub type AHashMap<K, V> = std::collections::HashMap<K,V, std::hash::BuildHasherDefault<AHasher>>;
-
-#[cfg(all(feature = "type-alias", not(feature = "std")))]
-pub type AHashSet<K> = std::collections::HashSet<K, std::hash::BuildHasherDefault<AHasher>>;
-
-#[cfg(all(not(feature = "type-alias"), feature = "std"))]
+#[cfg(feature = "std")]
 mod hash_map;
-#[cfg(all(not(feature = "type-alias"), feature = "std"))]
+#[cfg(feature = "std")]
 mod hash_set;
 mod operations;
 mod random_state;
@@ -64,26 +78,84 @@ mod specialize;
 
 #[cfg(any(
     all(any(target_arch = "x86", target_arch = "x86_64"), target_feature = "aes", not(miri)),
-    all(any(target_arch = "arm", target_arch = "aarch64"), target_feature = "crypto", not(miri), feature = "stdsimd")
+    all(
+        any(target_arch = "arm", target_arch = "aarch64"),
+        target_feature = "crypto",
+        not(miri),
+        feature = "stdsimd"
+    )
 ))]
 pub use crate::aes_hash::AHasher;
 
 #[cfg(not(any(
     all(any(target_arch = "x86", target_arch = "x86_64"), target_feature = "aes", not(miri)),
-    all(any(target_arch = "arm", target_arch = "aarch64"), target_feature = "crypto", not(miri), feature = "stdsimd")
+    all(
+        any(target_arch = "arm", target_arch = "aarch64"),
+        target_feature = "crypto",
+        not(miri),
+        feature = "stdsimd"
+    )
 )))]
 pub use crate::fallback_hash::AHasher;
 pub use crate::random_state::RandomState;
 
 pub use crate::specialize::CallHasher;
 
-#[cfg(all(not(feature = "type-alias"), feature = "std"))]
+#[cfg(feature = "std")]
 pub use crate::hash_map::AHashMap;
-#[cfg(all(not(feature = "type-alias"), feature = "std"))]
+#[cfg(feature = "std")]
 pub use crate::hash_set::AHashSet;
 use core::hash::BuildHasher;
 use core::hash::Hash;
 use core::hash::Hasher;
+
+#[cfg(feature = "std")]
+/// A convenience trait that can be used together with the type aliases defined to
+/// get access to the `new()` and `with_capacity()` methods for the HashMap type alias.
+pub trait HashMapExt {
+    /// Constructs a new HashMap
+    fn new() -> Self;
+    /// Constructs a new HashMap with a given initial capacity
+    fn with_capacity(capacity: usize) -> Self;
+}
+
+#[cfg(feature = "std")]
+/// A convenience trait that can be used together with the type aliases defined to
+/// get access to the `new()` and `with_capacity()` methods for the HashSet type aliases.
+pub trait HashSetExt {
+    /// Constructs a new HashSet
+    fn new() -> Self;
+    /// Constructs a new HashSet with a given initial capacity
+    fn with_capacity(capacity: usize) -> Self;
+}
+
+#[cfg(feature = "std")]
+impl<K, V, S> HashMapExt for std::collections::HashMap<K, V, S>
+where
+    S: BuildHasher + Default,
+{
+    fn new() -> Self {
+        std::collections::HashMap::with_hasher(S::default())
+    }
+
+    fn with_capacity(capacity: usize) -> Self {
+        std::collections::HashMap::with_capacity_and_hasher(capacity, S::default())
+    }
+}
+
+#[cfg(feature = "std")]
+impl<K, S> HashSetExt for std::collections::HashSet<K, S>
+where
+    S: BuildHasher + Default,
+{
+    fn new() -> Self {
+        std::collections::HashSet::with_hasher(S::default())
+    }
+
+    fn with_capacity(capacity: usize) -> Self {
+        std::collections::HashSet::with_capacity_and_hasher(capacity, S::default())
+    }
+}
 
 /// Provides a default [Hasher] with fixed keys.
 /// This is typically used in conjunction with [BuildHasherDefault] to create
@@ -200,24 +272,6 @@ impl<B: BuildHasher> BuildHasherExt for B {
 //     <[u8]>::get_hash(input, &a)
 // }
 
-#[cfg(all(feature = "type-alias", not(feature = "std")))]
-#[cfg(test)]
-mod test {
-    use super::*;
-
-    #[test]
-    fn test_ahash_map_construction() {
-        let mut map = AHashMap::with_capacity_and_hasher(1234, Default::default());
-        map.insert(1, "test");
-    }
-
-    #[test]
-    fn test_ahash_set_construction() {
-        let mut set = AHashSet::with_capacity_and_hasher(1234, Default::default());
-        set.insert(1);
-    }
-}
-
 #[cfg(feature = "std")]
 #[cfg(test)]
 mod test {
@@ -225,6 +279,18 @@ mod test {
     use crate::*;
     use std::collections::HashMap;
     use std::hash::Hash;
+
+    #[test]
+    fn test_ahash_alias_map_construction() {
+        let mut map = super::HashMap::with_capacity(1234);
+        map.insert(1, "test");
+    }
+
+    #[test]
+    fn test_ahash_alias_set_construction() {
+        let mut set = super::HashSet::with_capacity(1234);
+        set.insert(1);
+    }
 
     #[test]
     fn test_default_builder() {
@@ -247,7 +313,6 @@ mod test {
         assert_eq!(bytes, 0x6464646464646464);
     }
 
-
     #[test]
     fn test_non_zero() {
         let mut hasher1 = AHasher::new_with_keys(0, 0);
@@ -269,7 +334,7 @@ mod test {
 
     #[test]
     fn test_non_zero_specialized() {
-        let hasher_build = RandomState::with_seeds(0,0,0,0);
+        let hasher_build = RandomState::with_seeds(0, 0, 0, 0);
 
         let h1 = str::get_hash("foo", &hasher_build);
         let h2 = str::get_hash("bar", &hasher_build);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,7 @@
 //! let mut map: HashMap<i32, i32, RandomState> = HashMap::default();
 //! map.insert(12, 34);
 //! ```
-//! For convinence both new type wrappers and type aliases. The new type wrappers are called called `AHashMap` and `AHashSet`. These do the same thing with slightly less typing.
+//! For convenience, both new-type wrappers and type aliases are provided. The new type wrappers are called called `AHashMap` and `AHashSet`. These do the same thing with slightly less typing.
 //! The type aliases are called `ahash::HashMap`, `ahash::HashSet` are also provided and alias the
 //! std::[HashMap] and std::[HashSet]. Why are there two options? The wrappers are convenient but
 //! prevent you from using it as a swap in replacement for the normal std collections.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,7 +20,7 @@
 //! For convenience, both new-type wrappers and type aliases are provided. The new type wrappers are called called `AHashMap` and `AHashSet`. These do the same thing with slightly less typing.
 //! The type aliases are called `ahash::HashMap`, `ahash::HashSet` are also provided and alias the
 //! std::[HashMap] and std::[HashSet]. Why are there two options? The wrappers are convenient but
-//! prevent you from using it as a swap in replacement for the normal std collections.
+//! can't be used where a generic `std::collection::HashMap<K, V, S>` is required.
 //! 
 //! ```ignore
 //! use ahash::AHashMap;

--- a/tests/map_tests.rs
+++ b/tests/map_tests.rs
@@ -169,6 +169,25 @@ fn test_bucket_distribution() {
     check_for_collisions(&build_hasher, &sequence, 256);
 }
 
+#[test]
+fn test_ahash_alias_map_construction() {
+    let mut map = ahash::HashMap::default();
+    map.insert(1, "test");
+    use ahash::HashMapExt;
+    let mut map = ahash::HashMap::with_capacity(1234);
+    map.insert(1, "test");
+}
+
+#[test]
+fn test_ahash_alias_set_construction() {
+    let mut set = ahash::HashSet::default();
+    set.insert(1);
+
+    use ahash::HashSetExt;
+    let mut set = ahash::HashSet::with_capacity(1235);
+    set.insert(1);
+}
+
 fn ahash_vec<H: Hash>(b: &Vec<H>) -> u64 {
     let mut total: u64 = 0;
     for item in b {

--- a/tests/map_tests.rs
+++ b/tests/map_tests.rs
@@ -169,6 +169,7 @@ fn test_bucket_distribution() {
     check_for_collisions(&build_hasher, &sequence, 256);
 }
 
+#[cfg(feature = "std")]
 #[test]
 fn test_ahash_alias_map_construction() {
     let mut map = ahash::HashMap::default();
@@ -178,6 +179,7 @@ fn test_ahash_alias_map_construction() {
     map.insert(1, "test");
 }
 
+#[cfg(feature = "std")]
 #[test]
 fn test_ahash_alias_set_construction() {
     let mut set = ahash::HashSet::default();


### PR DESCRIPTION
Should fix https://github.com/tkaitchuck/aHash/issues/103

Adds a new feature which is mutually exclusive to the default "std" feature which adds a type-alias instead of a new type for the `AHashMap` and `AHashSet` types. This makes it possible to use `AHashMap::with_capacity_and_hasher(123, Default::default())` and pass it to 
```rust 
fn foo<K, V, S>(map: &HashMap<K, V, S>);
```
