### PR TITLE
Added From<array> for AHashSet & AHashMap

### DIFF
--- a/src/hash_map.rs
+++ b/src/hash_map.rs
@@ -25,6 +25,24 @@ impl<K, V> From<HashMap<K, V, crate::RandomState>> for AHashMap<K, V> {
     }
 }
 
+impl<K, V, const N: usize> From<[(K, V); N]> for AHashMap<K, V>
+where
+    K: Eq + Hash,
+{
+    /// # Examples
+    ///
+    /// ```
+    /// use ahash::AHashMap;
+    ///
+    /// let map1 = AHashMap::from([(1, 2), (3, 4)]);
+    /// let map2: AHashMap<_, _> = [(1, 2), (3, 4)].into();
+    /// assert_eq!(map1, map2);
+    /// ```
+    fn from(arr: [(K, V); N]) -> Self {
+        Self::from_iter(arr)
+    }
+}
+
 impl<K, V> Into<HashMap<K, V, crate::RandomState>> for AHashMap<K, V> {
     fn into(self) -> HashMap<K, V, crate::RandomState> {
         self.0

--- a/src/hash_set.rs
+++ b/src/hash_set.rs
@@ -22,6 +22,24 @@ impl<T> From<HashSet<T, crate::RandomState>> for AHashSet<T> {
     }
 }
 
+impl<T, const N: usize> From<[T; N]> for AHashSet<T>
+where
+    T: Eq + Hash,
+{
+    /// # Examples
+    ///
+    /// ```
+    /// use ahash::AHashSet;
+    ///
+    /// let set1 = AHashSet::from([1, 2, 3, 4]);
+    /// let set2: AHashSet<_> = [1, 2, 3, 4].into();
+    /// assert_eq!(set1, set2);
+    /// ```
+    fn from(arr: [T; N]) -> Self {
+        Self::from_iter(arr)
+    }
+}
+
 impl<T> Into<HashSet<T, crate::RandomState>> for AHashSet<T> {
     fn into(self) -> HashSet<T, crate::RandomState> {
         self.0


### PR DESCRIPTION
This adds the convenience [`From<array>`](https://doc.rust-lang.org/stable/std/collections/struct.HashSet.html#impl-From%3C%5BT%3B%20N%5D%3E) [methods](https://doc.rust-lang.org/stable/std/collections/struct.HashMap.html#impl-From%3C%5B(K%2C%20V)%3B%20N%5D%3E) to `AHashSet` & `AHashMap` that are found in the `std` `HashSet` & `HashMap`.

The code is more or less verbatim copied from `std` and contains examples (i.e. doc tests).