### PR TITLE
Improve codegen for mixing in length

### DIFF
--- a/src/operations.rs
+++ b/src/operations.rs
@@ -146,6 +146,29 @@ pub(crate) fn aesdec(value: u128, xor: u128) -> u128 {
     }
 }
 
+#[inline(always)]
+pub(crate) fn add_in_length(enc: &mut u128, len: u64) {
+    #[cfg(all(target_arch = "x86_64", target_feature = "sse2", not(miri)))]
+    {
+        #[cfg(target_arch = "x86_64")]
+        use core::arch::x86_64::*;
+
+        unsafe {
+            let enc = enc as *mut u128;
+            let len = _mm_cvtsi64_si128(len as i64);
+            let data = _mm_loadu_si128(enc.cast());
+            let sum = _mm_add_epi64(data, len);
+            _mm_storeu_si128(enc.cast(), sum);
+        }
+    }
+    #[cfg(not(all(target_arch = "x86_64", target_feature = "sse2", not(miri))))]
+    {
+        let mut t: [u64; 2] = enc.convert();
+        t[0] = t[0].wrapping_add(len);
+        *enc = t.convert();
+    }
+}
+
 #[cfg(test)]
 mod test {
     use super::*;
@@ -326,5 +349,13 @@ mod test {
             assert_ne!(numbered, shuffled, "Equal after {} vs {:x}", count, shuffled);
             shuffled = shuffle(shuffled);
         }
+    }
+
+    #[test]
+    fn test_add_length() {
+        let mut enc = (u64::MAX as u128) << 64 | 50;
+        add_in_length(&mut enc, u64::MAX);
+        assert_eq!(enc >> 64, u64::MAX as u128);
+        assert_eq!(enc as u64, 49);
     }
 }


### PR DESCRIPTION
Minor detail, but produces +17% speed improvement for small strings/byte slices (x86-64).


Measured on Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz (Skylake).
```
RUSTFLAGS="-C target-cpu=native" cargo bench aeshash/string

Before:
aeshash/string          time:   [69.371 ns 69.966 ns 70.507 ns]

After:
aeshash/string          time:   [56.352 ns 56.830 ns 57.309 ns]                           
                        change: [-18.211% -17.441% -16.670%] (p = 0.00 < 0.05)
```

---

Before (relevant part):
```asm
   	mov	  rsi, qword ptr [rbx + 16]	# length
   	vmovq	  rax, xmm1			# enc[0]
   	add	  rax, rsi
   	vmovq	  xmm3, rax
   	vpblendd  xmm11, xmm3, xmm1, 12
```
In order to add the length it extracts enc[0] into general-purpose register, adds there and then moves it back to vector register (and uses blend).

After:
```asm
   	vmovq	xmm3, qword ptr [rbx + 16]	# length
   	vpaddq	xmm11, xmm3, xmm1		# enc[0] += length
```
LLVM able to recognize there is no need to go through GRP and blend.