### PR TITLE
fix aes acceleration on aarch64

### DIFF
--- a/src/hash_quality_test.rs
+++ b/src/hash_quality_test.rs
@@ -397,7 +397,7 @@ mod fallback_tests {
 ///Basic sanity tests of the cypto properties of aHash.
 #[cfg(any(
     all(any(target_arch = "x86", target_arch = "x86_64"), target_feature = "aes", not(miri)),
-    all(any(target_arch = "arm", target_arch = "aarch64"), target_feature = "crypto", not(miri), feature = "stdsimd")
+    all(any(target_arch = "arm", target_arch = "aarch64"), any(target_feature = "aes", target_feature = "crypto"), not(miri), feature = "stdsimd")
 ))]
 #[cfg(test)]
 mod aes_tests {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,7 +49,7 @@ mod convert;
     all(any(target_arch = "x86", target_arch = "x86_64"), target_feature = "aes", not(miri)),
     all(
         any(target_arch = "arm", target_arch = "aarch64"),
-        target_feature = "crypto",
+        any(target_feature = "aes", target_feature = "crypto"),
         not(miri),
         feature = "stdsimd"
     )
@@ -80,7 +80,7 @@ mod specialize;
     all(any(target_arch = "x86", target_arch = "x86_64"), target_feature = "aes", not(miri)),
     all(
         any(target_arch = "arm", target_arch = "aarch64"),
-        target_feature = "crypto",
+        any(target_feature = "aes", target_feature = "crypto"),
         not(miri),
         feature = "stdsimd"
     )
@@ -91,7 +91,7 @@ pub use crate::aes_hash::AHasher;
     all(any(target_arch = "x86", target_arch = "x86_64"), target_feature = "aes", not(miri)),
     all(
         any(target_arch = "arm", target_arch = "aarch64"),
-        target_feature = "crypto",
+        any(target_feature = "aes", target_feature = "crypto"),
         not(miri),
         feature = "stdsimd"
     )

--- a/src/operations.rs
+++ b/src/operations.rs
@@ -101,7 +101,7 @@ pub(crate) fn aesenc(value: u128, xor: u128) -> u128 {
     }
 }
 
-#[cfg(all(any(target_arch = "arm", target_arch = "aarch64"), target_feature = "crypto", not(miri), feature = "stdsimd"))]
+#[cfg(all(any(target_arch = "arm", target_arch = "aarch64"), any(target_feature = "aes", target_feature = "crypto"), not(miri), feature = "stdsimd"))]
 #[allow(unused)]
 #[inline(always)]
 pub(crate) fn aesenc(value: u128, xor: u128) -> u128 {
@@ -131,7 +131,7 @@ pub(crate) fn aesdec(value: u128, xor: u128) -> u128 {
     }
 }
 
-#[cfg(all(any(target_arch = "arm", target_arch = "aarch64"), target_feature = "crypto", not(miri), feature = "stdsimd"))]
+#[cfg(all(any(target_arch = "arm", target_arch = "aarch64"), any(target_feature = "aes", target_feature = "crypto"), not(miri), feature = "stdsimd"))]
 #[allow(unused)]
 #[inline(always)]
 pub(crate) fn aesdec(value: u128, xor: u128) -> u128 {

--- a/src/random_state.rs
+++ b/src/random_state.rs
@@ -5,13 +5,13 @@ use crate::BuildHasherExt;
 
 #[cfg(any(
     all(any(target_arch = "x86", target_arch = "x86_64"), target_feature = "aes", not(miri)),
-    all(any(target_arch = "arm", target_arch = "aarch64"), target_feature = "crypto", not(miri), feature = "stdsimd")
+    all(any(target_arch = "arm", target_arch = "aarch64"), any(target_feature = "aes", target_feature = "crypto"), not(miri), feature = "stdsimd")
 ))]
 pub use crate::aes_hash::*;
 
 #[cfg(not(any(
     all(any(target_arch = "x86", target_arch = "x86_64"), target_feature = "aes", not(miri)),
-    all(any(target_arch = "arm", target_arch = "aarch64"), target_feature = "crypto", not(miri), feature = "stdsimd")
+    all(any(target_arch = "arm", target_arch = "aarch64"), any(target_feature = "aes", target_feature = "crypto"), not(miri), feature = "stdsimd")
 )))]
 pub use crate::fallback_hash::*;
 
@@ -36,12 +36,12 @@ use once_cell::race::OnceBox;
 
 #[cfg(any(
     all(any(target_arch = "x86", target_arch = "x86_64"), target_feature = "aes", not(miri)),
-    all(any(target_arch = "arm", target_arch = "aarch64"), target_feature = "crypto", not(miri), feature = "stdsimd")
+    all(any(target_arch = "arm", target_arch = "aarch64"), any(target_feature = "aes", target_feature = "crypto"), not(miri), feature = "stdsimd")
 ))]
 use crate::aes_hash::*;
 #[cfg(not(any(
     all(any(target_arch = "x86", target_arch = "x86_64"), target_feature = "aes", not(miri)),
-    all(any(target_arch = "arm", target_arch = "aarch64"), target_feature = "crypto", not(miri), feature = "stdsimd")
+    all(any(target_arch = "arm", target_arch = "aarch64"), any(target_feature = "aes", target_feature = "crypto"), not(miri), feature = "stdsimd")
 )))]
 use crate::fallback_hash::*;
 

--- a/tests/bench.rs
+++ b/tests/bench.rs
@@ -6,7 +6,7 @@ use std::hash::{Hash, Hasher};
 
 #[cfg(any(
     all(any(target_arch = "x86", target_arch = "x86_64"), target_feature = "aes", not(miri)),
-    all(any(target_arch = "arm", target_arch = "aarch64"), target_feature = "crypto", not(miri), feature = "stdsimd")
+    all(any(target_arch = "arm", target_arch = "aarch64"), any(target_feature = "aes", target_feature = "crypto"), not(miri), feature = "stdsimd")
 ))]
 fn aeshash<H: Hash>(b: &H) -> u64 {
     let build_hasher = RandomState::with_seeds(1, 2, 3, 4);
@@ -14,7 +14,7 @@ fn aeshash<H: Hash>(b: &H) -> u64 {
 }
 #[cfg(not(any(
     all(any(target_arch = "x86", target_arch = "x86_64"), target_feature = "aes", not(miri)),
-    all(any(target_arch = "arm", target_arch = "aarch64"), target_feature = "crypto", not(miri), feature = "stdsimd")
+    all(any(target_arch = "arm", target_arch = "aarch64"), any(target_feature = "aes", target_feature = "crypto"), not(miri), feature = "stdsimd")
 )))]
 fn aeshash<H: Hash>(_b: &H) -> u64 {
     panic!("aes must be enabled")
@@ -22,7 +22,7 @@ fn aeshash<H: Hash>(_b: &H) -> u64 {
 
 #[cfg(not(any(
     all(any(target_arch = "x86", target_arch = "x86_64"), target_feature = "aes", not(miri)),
-    all(any(target_arch = "arm", target_arch = "aarch64"), target_feature = "crypto", not(miri), feature = "stdsimd")
+    all(any(target_arch = "arm", target_arch = "aarch64"), any(target_feature = "aes", target_feature = "crypto"), not(miri), feature = "stdsimd")
 )))]
 fn fallbackhash<H: Hash>(b: &H) -> u64 {
     let build_hasher = RandomState::with_seeds(1, 2, 3, 4);
@@ -30,7 +30,7 @@ fn fallbackhash<H: Hash>(b: &H) -> u64 {
 }
 #[cfg(any(
     all(any(target_arch = "x86", target_arch = "x86_64"), target_feature = "aes", not(miri)),
-    all(any(target_arch = "arm", target_arch = "aarch64"), target_feature = "crypto", not(miri), feature = "stdsimd")
+    all(any(target_arch = "arm", target_arch = "aarch64"), any(target_feature = "aes", target_feature = "crypto"), not(miri), feature = "stdsimd")
 ))]
 fn fallbackhash<H: Hash>(_b: &H) -> u64 {
     panic!("aes must be disabled")
@@ -82,6 +82,7 @@ const U32_VALUE: u32 = 12345678;
 const U64_VALUE: u64 = 1234567890123456;
 const U128_VALUE: u128 = 12345678901234567890123456789012;
 
+#[cfg(target_feature = "aes")]
 fn bench_ahash(c: &mut Criterion) {
     let mut group = c.benchmark_group("aeshash");
     group.bench_with_input("u8", &U8_VALUE, |b, s| b.iter(|| black_box(aeshash(s))));
@@ -92,6 +93,7 @@ fn bench_ahash(c: &mut Criterion) {
     group.bench_with_input("string", &gen_strings(), |b, s| b.iter(|| black_box(aeshash(s))));
 }
 
+#[cfg(not(target_feature = "aes"))]
 fn bench_fallback(c: &mut Criterion) {
     let mut group = c.benchmark_group("fallback");
     group.bench_with_input("u8", &U8_VALUE, |b, s| b.iter(|| black_box(fallbackhash(s))));
@@ -143,9 +145,26 @@ fn bench_sip(c: &mut Criterion) {
 }
 
 criterion_main!(benches);
+
+#[cfg(any(
+    all(any(target_arch = "x86", target_arch = "x86_64"), target_feature = "aes", not(miri)),
+    all(any(target_arch = "arm", target_arch = "aarch64"), any(target_feature = "aes", target_feature = "crypto"), not(miri), feature = "stdsimd")
+))]
 criterion_group!(
     benches,
     bench_ahash,
+    bench_fx,
+    bench_fnv,
+    bench_sea,
+    bench_sip
+);
+
+#[cfg(not(any(
+    all(any(target_arch = "x86", target_arch = "x86_64"), target_feature = "aes", not(miri)),
+    all(any(target_arch = "arm", target_arch = "aarch64"), any(target_feature = "aes", target_feature = "crypto"), not(miri), feature = "stdsimd")
+)))]
+criterion_group!(
+    benches,
     bench_fallback,
     bench_fx,
     bench_fnv,


### PR DESCRIPTION
The target feature on aarch64 has been renamed from `crypto` to
`aes` for newer versions of the rust compiler.

Makes necessary changes to fix use of aes instructions on aarch64.