### PR TITLE
Simplify interface

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -148,4 +148,4 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: check
-          args: --target wasm32-unknown-unknown
+          args: --target wasm32-unknown-unknown --no-default-features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,13 +78,14 @@ once_cell = { version = "1.8", default-features = false, features = ["unstable",
 
 [dev-dependencies]
 no-panic = "0.1.10"
-criterion = {version =  "0.3.2"}
+criterion = {version =  "0.3.2", features = ["html_reports"] }
 seahash = "4.0"
 fnv = "1.0.5"
 fxhash = "0.2.1"
 hex = "0.4.2"
 rand = "0.7.3"
 serde_json = "1.0.59"
+hashbrown = { version = "0.12.0" }
 
 [package.metadata.docs.rs]
 rustc-args = ["-C", "target-feature=+aes"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,6 +72,7 @@ once_cell = { version = "1.8", default-features = false, features = ["unstable",
 getrandom = { version = "0.2.3", optional = true }
 const-random = { version = "0.1.12", optional = true }
 serde = { version = "1.0.117", optional = true }
+cfg-if = "1.0"
 
 [target.'cfg(not(all(target_arch = "arm", target_os = "none")))'.dependencies]
 once_cell = { version = "1.8", default-features = false, features = ["alloc"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,10 +28,10 @@ default = ["std", "runtime-rng"]
 std = []
 
 # Runtime random key generation using getrandom.
-runtime-rng = ["getrandom", "once_cell"]
+runtime-rng = ["getrandom"]
 
 # This is an alternative to runtime key generation which does compile time key generation if runtime-rng is not available.
-# (If runtime-rng is available this does nothing.)
+# (If runtime-rng is enabled this does nothing.)
 # If this is on (and runtime-rng is off) it implies the produced binary will not be identical.
 # If this is disabled and runtime-rng is unavailable constant keys are used.
 compile-time-rng = ["const-random"]
@@ -68,14 +68,13 @@ codegen-units = 1
 version_check = "0.9"
 
 [dependencies]
-once_cell = { version = "1.8", default-features = false, features = ["unstable", "alloc"], optional = true }
 getrandom = { version = "0.2.3", optional = true }
 const-random = { version = "0.1.12", optional = true }
 serde = { version = "1.0.117", optional = true }
 cfg-if = "1.0"
 
 [target.'cfg(not(all(target_arch = "arm", target_os = "none")))'.dependencies]
-once_cell = { version = "1.8", default-features = false, features = ["alloc"] }
+once_cell = { version = "1.8", default-features = false, features = ["unstable", "alloc"] }
 
 [dev-dependencies]
 no-panic = "0.1.10"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ahash"
-version = "0.7.6"
+version = "0.8.0"
 authors = ["Tom Kaitchuck <Tom.Kaitchuck@gmail.com>"]
 license = "MIT OR Apache-2.0"
 description = "A non-cryptographic hash function using AES-NI for high performance"
@@ -83,9 +83,9 @@ seahash = "4.0"
 fnv = "1.0.5"
 fxhash = "0.2.1"
 hex = "0.4.2"
-rand = "0.7.3"
+rand = "0.8.5"
 serde_json = "1.0.59"
-hashbrown = { version = "0.12.0" }
+hashbrown = "0.12.3"
 
 [package.metadata.docs.rs]
 rustc-args = ["-C", "target-feature=+aes"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,15 +22,18 @@ bench = true
 doc = true
 
 [features]
-default = ["std"]
+default = ["std", "runtime-rng"]
 
 # Enabling this will enable `AHashMap` and `AHashSet`.
 std = []
 
-# This is an alternitive to runtime key generation which does compile time key generation if getrandom is not available.
-# (If getrandom is available this does nothing.)
-# If this is on (and getrandom is off) it implies the produced binary will not be identical.
-# If this is disabled and gerrandom is unavailable constant keys are used.
+# Runtime random key generation using getrandom.
+runtime-rng = ["getrandom", "once_cell"]
+
+# This is an alternative to runtime key generation which does compile time key generation if runtime-rng is not available.
+# (If runtime-rng is available this does nothing.)
+# If this is on (and runtime-rng is off) it implies the produced binary will not be identical.
+# If this is disabled and runtime-rng is unavailable constant keys are used.
 compile-time-rng = ["const-random"]
 
 [[bench]]
@@ -64,12 +67,9 @@ codegen-units = 1
 [build-dependencies]
 version_check = "0.9"
 
-[target.'cfg(any(target_os = "linux", target_os = "android", target_os = "windows", target_os = "macos", target_os = "ios", target_os = "freebsd", target_os = "openbsd", target_os = "netbsd", target_os = "dragonfly", target_os = "solaris", target_os = "illumos", target_os = "fuchsia", target_os = "redox", target_os = "cloudabi", target_os = "haiku", target_os = "vxworks", target_os = "emscripten", target_os = "wasi"))'.dependencies]
-getrandom = { version = "0.2.3" }
-const-random = { version = "0.1.12", optional = true }
-serde = { version = "1.0.117", optional = true }
-
-[target.'cfg(not(any(target_os = "linux", target_os = "android", target_os = "windows", target_os = "macos", target_os = "ios", target_os = "freebsd", target_os = "openbsd", target_os = "netbsd", target_os = "dragonfly", target_os = "solaris", target_os = "illumos", target_os = "fuchsia", target_os = "redox", target_os = "cloudabi", target_os = "haiku", target_os = "vxworks", target_os = "emscripten", target_os = "wasi")))'.dependencies]
+[dependencies]
+once_cell = { version = "1.8", default-features = false, features = ["unstable", "alloc"], optional = true }
+getrandom = { version = "0.2.3", optional = true }
 const-random = { version = "0.1.12", optional = true }
 serde = { version = "1.0.117", optional = true }
 

--- a/build.rs
+++ b/build.rs
@@ -10,27 +10,6 @@ fn main() {
             println!("cargo:rustc-cfg=feature=\"stdsimd\"");
         }
     }
-    let os = env::var("CARGO_CFG_TARGET_OS").expect("CARGO_CFG_TARGET_OS was not set");
-    if os.eq_ignore_ascii_case("linux")
-        || os.eq_ignore_ascii_case("android")
-        || os.eq_ignore_ascii_case("windows")
-        || os.eq_ignore_ascii_case("macos")
-        || os.eq_ignore_ascii_case("ios")
-        || os.eq_ignore_ascii_case("freebsd")
-        || os.eq_ignore_ascii_case("openbsd")
-        || os.eq_ignore_ascii_case("dragonfly")
-        || os.eq_ignore_ascii_case("solaris")
-        || os.eq_ignore_ascii_case("illumos")
-        || os.eq_ignore_ascii_case("fuchsia")
-        || os.eq_ignore_ascii_case("redox")
-        || os.eq_ignore_ascii_case("cloudabi")
-        || os.eq_ignore_ascii_case("haiku")
-        || os.eq_ignore_ascii_case("vxworks")
-        || os.eq_ignore_ascii_case("emscripten")
-        || os.eq_ignore_ascii_case("wasi")
-    {
-        println!("cargo:rustc-cfg=feature=\"runtime-rng\"");
-    }
     let arch = env::var("CARGO_CFG_TARGET_ARCH").expect("CARGO_CFG_TARGET_ARCH was not set");
     if arch.eq_ignore_ascii_case("x86_64")
         || arch.eq_ignore_ascii_case("aarch64")

--- a/smhasher/ahash-cbindings/src/lib.rs
+++ b/smhasher/ahash-cbindings/src/lib.rs
@@ -1,10 +1,12 @@
+#![feature(build_hasher_simple_hash_one)]
+
 use ahash::*;
 use core::slice;
-use std::hash::{BuildHasher, Hasher};
+use std::hash::{BuildHasher};
 
 #[no_mangle]
 pub extern "C" fn ahash64(buf: *const (), len: usize, seed: u64) -> u64 {
     let buf: &[u8] = unsafe { slice::from_raw_parts(buf as *const u8, len) };
-    let build_hasher = RandomState::with_seeds(seed, 0, 0, 0);
-    <[u8]>::get_hash(&buf, &build_hasher)
+    let build_hasher = RandomState::with_seed(seed as usize);
+    build_hasher.hash_one(&buf)
 }

--- a/src/aes_hash.rs
+++ b/src/aes_hash.rs
@@ -48,7 +48,7 @@ impl AHasher {
     /// println!("Hash is {:x}!", hasher.finish());
     /// ```
     #[inline]
-    pub fn new_with_keys(key1: u128, key2: u128) -> Self {
+    pub(crate) fn new_with_keys(key1: u128, key2: u128) -> Self {
         let pi: [u128; 2] = PI.convert();
         let key1 = key1 ^ pi[0];
         let key2 = key2 ^ pi[1];

--- a/src/aes_hash.rs
+++ b/src/aes_hash.rs
@@ -1,6 +1,4 @@
 use crate::convert::*;
-#[cfg(feature = "specialize")]
-use crate::fallback_hash::MULTIPLE;
 use crate::operations::*;
 use crate::RandomState;
 use core::hash::Hasher;

--- a/src/fallback_hash.rs
+++ b/src/fallback_hash.rs
@@ -32,7 +32,7 @@ impl AHasher {
     /// Creates a new hasher keyed to the provided key.
     #[inline]
     #[allow(dead_code)] // Is not called if non-fallback hash is used.
-    pub fn new_with_keys(key1: u128, key2: u128) -> AHasher {
+    pub(crate) fn new_with_keys(key1: u128, key2: u128) -> AHasher {
         let pi: [u128; 2] = PI.convert();
         let key1: [u64; 2] = (key1 ^ pi[0]).convert();
         let key2: [u64; 2] = (key2 ^ pi[1]).convert();

--- a/src/fallback_hash.rs
+++ b/src/fallback_hash.rs
@@ -1,12 +1,13 @@
 use crate::convert::*;
 use crate::operations::folded_multiply;
 use crate::operations::read_small;
+use crate::operations::MULTIPLE;
 use crate::random_state::PI;
 use crate::RandomState;
 use core::hash::Hasher;
 
-///This constant come from Kunth's prng (Empirically it works better than those from splitmix32).
-pub(crate) const MULTIPLE: u64 = 6364136223846793005;
+
+
 const ROT: u32 = 23; //17
 
 /// A `Hasher` for hashing an arbitrary stream of bytes.

--- a/src/hash_map.rs
+++ b/src/hash_map.rs
@@ -163,8 +163,6 @@ where
     /// types that can be `==` without being identical. See the [module-level
     /// documentation] for more.
     ///
-    /// [module-level documentation]: crate::collections#insert-and-complex-keys
-    ///
     /// # Examples
     ///
     /// ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,7 +89,7 @@ cfg_if::cfg_if! {
 mod hash_quality_test;
 
 mod operations;
-mod random_state;
+pub mod random_state;
 mod specialize;
 
 pub use crate::random_state::RandomState;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,8 +74,6 @@ mod specialize;
 
 pub use crate::random_state::RandomState;
 
-pub use crate::specialize::CallHasher;
-
 use core::hash::BuildHasher;
 use core::hash::Hash;
 use core::hash::Hasher;
@@ -202,6 +200,7 @@ mod test {
     use crate::*;
     use std::collections::HashMap;
     use std::hash::Hash;
+    use crate::specialize::CallHasher;
 
     #[test]
     fn test_default_builder() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,26 +71,20 @@ cfg_if::cfg_if! {
 
         pub use crate::hash_map::AHashMap;
         pub use crate::hash_set::AHashSet;
+
+        /// [Hasher]: std::hash::Hasher
+        /// [HashMap]: std::collections::HashMap
+        /// Type alias for [HashMap]<K, V, ahash::RandomState>
+        pub type HashMap<K, V> = std::collections::HashMap<K, V, crate::RandomState>;
+
+        /// Type alias for [HashSet]<K, ahash::RandomState>
+        pub type HashSet<K> = std::collections::HashSet<K, crate::RandomState>;
     }
 }
 
 #[cfg(test)]
 mod hash_quality_test;
 
-
-#[cfg(feature = "std")]
-/// [Hasher]: std::hash::Hasher
-/// [HashMap]: std::collections::HashMap
-/// Type alias for [HashMap]<K, V, ahash::RandomState>
-pub type HashMap<K, V> = std::collections::HashMap<K, V, crate::RandomState>;
-#[cfg(feature = "std")]
-/// Type alias for [HashSet]<K, ahash::RandomState>
-pub type HashSet<K> = std::collections::HashSet<K, crate::RandomState>;
-
-#[cfg(feature = "std")]
-mod hash_map;
-#[cfg(feature = "std")]
-mod hash_set;
 mod operations;
 mod random_state;
 mod specialize;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,6 +35,7 @@ map.insert(56, 78);
 #![allow(clippy::pedantic, clippy::cast_lossless, clippy::unreadable_literal)]
 #![cfg_attr(all(not(test), not(feature = "std")), no_std)]
 #![cfg_attr(feature = "specialize", feature(min_specialization))]
+#![cfg_attr(feature = "specialize", feature(build_hasher_simple_hash_one))]
 #![cfg_attr(feature = "stdsimd", feature(stdsimd))]
 
 #[macro_use]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,6 +39,9 @@ map.insert(56, 78);
 
 #[macro_use]
 mod convert;
+
+mod fallback_hash;
+
 cfg_if::cfg_if! {
     if #[cfg(any(
             all(any(target_arch = "x86", target_arch = "x86_64"), target_feature = "aes", not(miri)),
@@ -47,7 +50,6 @@ cfg_if::cfg_if! {
         mod aes_hash;
         pub use crate::aes_hash::AHasher;
     } else {
-        mod fallback_hash;
         pub use crate::fallback_hash::AHasher;
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,7 +19,7 @@
 //! ```
 //! For convinence wrappers called `AHashMap` and `AHashSet` are also provided.
 //! These to the same thing with slightly less typing.
-//! ```ignore
+//! ```
 //! use ahash::AHashMap;
 //!
 //! let mut map: AHashMap<i32, i32> = AHashMap::with_capacity(4);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,24 +8,29 @@
 //!
 //! aHash uses the hardware AES instruction on x86 processors to provide a keyed hash function.
 //! aHash is not a cryptographically secure hash.
-//!
-//! # Example
-//! ```
-//! use ahash::{AHasher, RandomState};
-//! use std::collections::HashMap;
-//!
-//! let mut map: HashMap<i32, i32, RandomState> = HashMap::default();
-//! map.insert(12, 34);
-//! ```
-//! For convinence wrappers called `AHashMap` and `AHashSet` are also provided.
-//! These to the same thing with slightly less typing.
-//! ```
-//! use ahash::AHashMap;
-//!
-//! let mut map: AHashMap<i32, i32> = AHashMap::with_capacity(4);
-//! map.insert(12, 34);
-//! map.insert(56, 78);
-//! ```
+//! 
+#![cfg_attr(any(feature = "compile-time-rng", feature = "runtime-rng"), doc = r##"
+# Example
+```
+use ahash::{AHasher, RandomState};
+use std::collections::HashMap;
+
+let mut map: HashMap<i32, i32, RandomState> = HashMap::default();
+map.insert(12, 34);
+```
+"##)]
+#![cfg_attr(feature = "std", doc = r##"
+For convinence wrappers called `AHashMap` and `AHashSet` are also provided.
+These to the same thing with slightly less typing.
+```
+use ahash::AHashMap;
+
+let mut map: AHashMap<i32, i32> = AHashMap::with_capacity(4);
+map.insert(12, 34);
+map.insert(56, 78);
+```
+"##)]
+
 #![deny(clippy::correctness, clippy::complexity, clippy::perf)]
 #![allow(clippy::pedantic, clippy::cast_lossless, clippy::unreadable_literal)]
 #![cfg_attr(all(not(test), not(feature = "std")), no_std)]

--- a/src/operations.rs
+++ b/src/operations.rs
@@ -1,5 +1,8 @@
 use crate::convert::*;
 
+///This constant come from Kunth's prng (Empirically it works better than those from splitmix32).
+pub(crate) const MULTIPLE: u64 = 6364136223846793005;
+
 /// This is a constant with a lot of special properties found by automated search.
 /// See the unit tests below. (Below are alternative values)
 #[cfg(all(target_feature = "ssse3", not(miri)))]

--- a/src/operations.rs
+++ b/src/operations.rs
@@ -63,7 +63,7 @@ pub(crate) fn add_and_shuffle(a: u128, b: u128) -> u128 {
     shuffle(sum.convert())
 }
 
-#[allow(unused)] //not used by fallbac
+#[allow(unused)] //not used by fallback
 #[inline(always)]
 pub(crate) fn shuffle_and_add(base: u128, to_add: u128) -> u128 {
     let shuffled: [u64; 2] = shuffle(base).convert();
@@ -149,6 +149,7 @@ pub(crate) fn aesdec(value: u128, xor: u128) -> u128 {
     }
 }
 
+#[allow(unused)]
 #[inline(always)]
 pub(crate) fn add_in_length(enc: &mut u128, len: u64) {
     #[cfg(all(target_arch = "x86_64", target_feature = "sse2", not(miri)))]

--- a/src/random_state.rs
+++ b/src/random_state.rs
@@ -269,6 +269,16 @@ impl RandomState {
         RandomState { k0: k0 ^ PI2[0], k1: k1 ^ PI2[1], k2: k2 ^ PI2[2], k3: k3 ^ PI2[3] }
     }
 
+    /// Calculates the hash of a single value.
+    ///
+    /// This is intended as a convenience for code which *consumes* hashes, such
+    /// as the implementation of a hash table or in unit tests that check
+    /// whether a custom [`Hash`] implementation behaves as expected.
+    ///
+    /// This must not be used in any code which *creates* hashes, such as in an
+    /// implementation of [`Hash`].  The way to create a combined hash of
+    /// multiple values is to call [`Hash::hash`] multiple times using the same
+    /// [`Hasher`], not to call this method repeatedly and combine the results.
     #[inline]
     pub fn hash_one<T: Hash>(&self, x: T) -> u64
         where Self: Sized {
@@ -321,6 +331,16 @@ impl BuildHasher for RandomState {
         AHasher::from_random_state(self)
     }
 
+    /// Calculates the hash of a single value.
+    ///
+    /// This is intended as a convenience for code which *consumes* hashes, such
+    /// as the implementation of a hash table or in unit tests that check
+    /// whether a custom [`Hash`] implementation behaves as expected.
+    ///
+    /// This must not be used in any code which *creates* hashes, such as in an
+    /// implementation of [`Hash`].  The way to create a combined hash of
+    /// multiple values is to call [`Hash::hash`] multiple times using the same
+    /// [`Hasher`], not to call this method repeatedly and combine the results.
     #[cfg(feature = "specialize")]
     #[inline]
     fn hash_one<T: Hash>(&self, x: T) -> u64 {

--- a/src/random_state.rs
+++ b/src/random_state.rs
@@ -64,7 +64,7 @@ cfg_if::cfg_if! {
             ];
             &RAND
         }
-    } else if #[cfg(feature = "runtime-rng")] {
+    } else if #[cfg(all(feature = "runtime-rng", not(fuzzing)))] {
         fn get_fixed_seeds() -> &'static [[u64; 4]; 2] {
             use crate::convert::Convert;
         

--- a/src/random_state.rs
+++ b/src/random_state.rs
@@ -127,6 +127,13 @@ impl DefaultRandomSource {
             counter: AtomicUsize::new(&PI as *const _ as usize),
         }
     }
+
+    #[cfg(all(target_arch = "arm", target_os = "none"))]
+    const fn default() -> DefaultRandomSource {
+        DefaultRandomSource {
+            counter: AtomicUsize::new(PI[3] as usize),
+        }
+    }
 }
 
 impl RandomSource for DefaultRandomSource {
@@ -173,7 +180,7 @@ impl RandomState {
         if #[cfg(all(target_arch = "arm", target_os = "none"))] {
             #[inline]
             fn get_src() -> &'static dyn RandomSource {
-                static RAND_SOURCE: DefaultRandomSource = DefaultRandomSource::new();
+                static RAND_SOURCE: DefaultRandomSource = DefaultRandomSource::default();
                 &RAND_SOURCE
             }
         } else {

--- a/src/random_state.rs
+++ b/src/random_state.rs
@@ -4,9 +4,9 @@ cfg_if::cfg_if! {
         all(any(target_arch = "x86", target_arch = "x86_64"), target_feature = "aes", not(miri)),
          all(any(target_arch = "arm", target_arch = "aarch64"), any(target_feature = "aes", target_feature = "crypto"), not(miri), feature = "stdsimd")
     ))] {
-        pub use crate::aes_hash::*;
+        use crate::aes_hash::*;
     } else {
-        pub use crate::fallback_hash::*;
+        use crate::fallback_hash::*;
     }
 }
 cfg_if::cfg_if! {
@@ -113,7 +113,7 @@ cfg_if::cfg_if! {
     }
 }
 /// A supplier of Randomness used for different hashers.
-/// See [RandomState::set_random_source].
+/// See [set_random_source].
 pub trait RandomSource {
 
     fn gen_hasher_seed(&self) -> usize;

--- a/src/random_state.rs
+++ b/src/random_state.rs
@@ -46,6 +46,7 @@ pub(crate) const PI2: [u64; 4] = [
 
 cfg_if::cfg_if! {
     if #[cfg(all(feature = "compile-time-rng", any(test, fuzzing)))] {
+        #[inline]
         fn get_fixed_seeds() -> &'static [[u64; 4]; 2] {
             use const_random::const_random;
         
@@ -65,6 +66,7 @@ cfg_if::cfg_if! {
             &RAND
         }
     } else if #[cfg(all(feature = "runtime-rng", not(fuzzing)))] {
+        #[inline]
         fn get_fixed_seeds() -> &'static [[u64; 4]; 2] {
             use crate::convert::Convert;
         
@@ -77,6 +79,7 @@ cfg_if::cfg_if! {
             })
         }
     } else if #[cfg(feature = "compile-time-rng")] {
+        #[inline]
         fn get_fixed_seeds() -> &'static [[u64; 4]; 2] {
             use const_random::const_random;
         

--- a/src/random_state.rs
+++ b/src/random_state.rs
@@ -308,6 +308,14 @@ impl BuildHasher for RandomState {
     fn build_hasher(&self) -> AHasher {
         AHasher::from_random_state(self)
     }
+
+    #[cfg(feature = "specialize")]
+    #[inline]
+    fn hash_one<T: Hash>(&self, x: T) -> u64
+        where Self: Sized {
+        use crate::specialize::CallHasher;
+        T::get_hash(&x, self)
+    }
 }
 
 #[cfg(feature = "specialize")]

--- a/src/specialize.rs
+++ b/src/specialize.rs
@@ -17,29 +17,7 @@ use alloc::vec::Vec;
 /// Provides a way to get an optimized hasher for a given data type.
 /// Rather than using a Hasher generically which can hash any value, this provides a way to get a specialized hash
 /// for a specific type. So this may be faster for primitive types.
-/// # Example
-/// ```
-/// use std::hash::BuildHasher;
-/// use ahash::RandomState;
-/// use ahash::CallHasher;
-///
-#[cfg_attr(any(feature = "compile-time-rng", feature = "runtime-rng"), doc = "let hash_builder = RandomState::new();")]
-#[cfg_attr(not(any(feature = "compile-time-rng", feature = "runtime-rng")), doc = "let hash_builder = RandomState::generate_with(1, 2, 3, 4);")]
-/// //...
-/// let value: u32 = 17;
-/// let hash = u32::get_hash(&value, &hash_builder);
-/// ```
-/// Note that the type used to invoke `get_hash` must be the same a the type of value passed.
-/// For example get a hasher specialized on `[u8]` can invoke:
-/// ```
-/// /// use std::hash::BuildHasher;
-/// # use ahash::RandomState;
-/// # use ahash::CallHasher;
-/// # let hash_builder = RandomState::generate_with(1, 2, 3, 4);
-/// let bytes: [u8; 4] = [1, 2, 3, 4];
-/// let hash = <[u8]>::get_hash(&bytes, &hash_builder);
-/// ```
-pub trait CallHasher {
+pub(crate) trait CallHasher {
     fn get_hash<H: Hash + ?Sized, B: BuildHasher>(value: &H, build_hasher: &B) -> u64;
 }
 

--- a/src/specialize.rs
+++ b/src/specialize.rs
@@ -23,7 +23,8 @@ use alloc::vec::Vec;
 /// use ahash::RandomState;
 /// use ahash::CallHasher;
 ///
-/// let hash_builder = RandomState::new();
+#[cfg_attr(any(feature = "compile-time-rng", feature = "runtime-rng"), doc = "let hash_builder = RandomState::new();")]
+#[cfg_attr(not(any(feature = "compile-time-rng", feature = "runtime-rng")), doc = "let hash_builder = RandomState::generate_with(1, 2, 3, 4);")]
 /// //...
 /// let value: u32 = 17;
 /// let hash = u32::get_hash(&value, &hash_builder);
@@ -34,7 +35,7 @@ use alloc::vec::Vec;
 /// /// use std::hash::BuildHasher;
 /// # use ahash::RandomState;
 /// # use ahash::CallHasher;
-/// # let hash_builder = RandomState::new();
+/// # let hash_builder = RandomState::generate_with(1, 2, 3, 4);
 /// let bytes: [u8; 4] = [1, 2, 3, 4];
 /// let hash = <[u8]>::get_hash(&bytes, &hash_builder);
 /// ```

--- a/tests/bench.rs
+++ b/tests/bench.rs
@@ -147,61 +147,64 @@ fn bench_sip(c: &mut Criterion) {
 }
 
 fn bench_map(c: &mut Criterion) {
-    let mut group = c.benchmark_group("map");
-    group.bench_function("aHash-alias", |b| b.iter(|| {
-        let hm: ahash::HashMap<i32, i32> = (0..1_000_000).map(|i| (i, i)).collect();
-        let mut sum = 0;
-        for i in 0..1_000_000 {
-            if let Some(x) = hm.get(&i) {
-                sum += x;
-            }
+    #[cfg(feature = "std")]
+        {
+            let mut group = c.benchmark_group("map");
+            group.bench_function("aHash-alias", |b| b.iter(|| {
+                let hm: ahash::HashMap<i32, i32> = (0..1_000_000).map(|i| (i, i)).collect();
+                let mut sum = 0;
+                for i in 0..1_000_000 {
+                    if let Some(x) = hm.get(&i) {
+                        sum += x;
+                    }
+                }
+            }));
+            group.bench_function("aHash-hashBrown", |b| b.iter(|| {
+                let hm: hashbrown::HashMap<i32, i32> = (0..1_000_000).map(|i| (i, i)).collect();
+                let mut sum = 0;
+                for i in 0..1_000_000 {
+                    if let Some(x) = hm.get(&i) {
+                        sum += x;
+                    }
+                }
+            }));
+            group.bench_function("aHash-hashBrown-explicit", |b| b.iter(|| {
+                let hm: hashbrown::HashMap<i32, i32, RandomState> = (0..1_000_000).map(|i| (i, i)).collect();
+                let mut sum = 0;
+                for i in 0..1_000_000 {
+                    if let Some(x) = hm.get(&i) {
+                        sum += x;
+                    }
+                }
+            }));
+            group.bench_function("aHash-wrapper", |b| b.iter(|| {
+                let hm: ahash::AHashMap<i32, i32> = (0..1_000_000).map(|i| (i, i)).collect();
+                let mut sum = 0;
+                for i in 0..1_000_000 {
+                    if let Some(x) = hm.get(&i) {
+                        sum += x;
+                    }
+                }
+            }));
+            group.bench_function("aHash-rand", |b| b.iter(|| {
+                let hm: std::collections::HashMap<i32, i32, RandomState> = (0..1_000_000).map(|i| (i, i)).collect();
+                let mut sum = 0;
+                for i in 0..1_000_000 {
+                    if let Some(x) = hm.get(&i) {
+                        sum += x;
+                    }
+                }
+            }));
+            group.bench_function("aHash-default", |b| b.iter(|| {
+                let hm: std::collections::HashMap<i32, i32, BuildHasherDefault<AHasher>> = (0..1_000_000).map(|i| (i, i)).collect();
+                let mut sum = 0;
+                for i in 0..1_000_000 {
+                    if let Some(x) = hm.get(&i) {
+                        sum += x;
+                    }
+                }
+            }));
         }
-    }));
-    group.bench_function("aHash-hashBrown", |b| b.iter(|| {
-        let hm: hashbrown::HashMap<i32, i32> = (0..1_000_000).map(|i| (i, i)).collect();
-        let mut sum = 0;
-        for i in 0..1_000_000 {
-            if let Some(x) = hm.get(&i) {
-                sum += x;
-            }
-        }
-    }));
-    group.bench_function("aHash-hashBrown-explicit", |b| b.iter(|| {
-        let hm: hashbrown::HashMap<i32, i32, RandomState> = (0..1_000_000).map(|i| (i, i)).collect();
-        let mut sum = 0;
-        for i in 0..1_000_000 {
-            if let Some(x) = hm.get(&i) {
-                sum += x;
-            }
-        }
-    }));
-    group.bench_function("aHash-wrapper", |b| b.iter(|| {
-        let hm: ahash::AHashMap<i32, i32> = (0..1_000_000).map(|i| (i, i)).collect();
-        let mut sum = 0;
-        for i in 0..1_000_000 {
-            if let Some(x) = hm.get(&i) {
-                sum += x;
-            }
-        }
-    }));
-    group.bench_function("aHash-rand", |b| b.iter(|| {
-        let hm: std::collections::HashMap<i32, i32, RandomState> = (0..1_000_000).map(|i| (i, i)).collect();
-        let mut sum = 0;
-        for i in 0..1_000_000 {
-            if let Some(x) = hm.get(&i) {
-                sum += x;
-            }
-        }
-    }));
-    group.bench_function("aHash-default", |b| b.iter(|| {
-        let hm: std::collections::HashMap<i32, i32, BuildHasherDefault<AHasher>> = (0..1_000_000).map(|i| (i, i)).collect();
-        let mut sum = 0;
-        for i in 0..1_000_000 {
-            if let Some(x) = hm.get(&i) {
-                sum += x;
-            }
-        }
-    }));
 }
 
 criterion_main!(benches);

--- a/tests/bench.rs
+++ b/tests/bench.rs
@@ -1,10 +1,10 @@
-#![feature(build_hasher_simple_hash_one)]
+#![cfg_attr(feature = "specialize", feature(build_hasher_simple_hash_one))]
 
 use ahash::{AHasher, RandomState};
 use criterion::*;
 use fxhash::FxHasher;
 use std::collections::hash_map::DefaultHasher;
-use std::hash::{BuildHasher, BuildHasherDefault, Hash, Hasher};
+use std::hash::{BuildHasherDefault, Hash, Hasher};
 
 #[cfg(any(
     all(any(target_arch = "x86", target_arch = "x86_64"), target_feature = "aes", not(miri)),

--- a/tests/bench.rs
+++ b/tests/bench.rs
@@ -1,8 +1,10 @@
-use ahash::{CallHasher, RandomState};
+#![feature(build_hasher_simple_hash_one)]
+
+use ahash::{RandomState};
 use criterion::*;
 use fxhash::FxHasher;
 use std::collections::hash_map::DefaultHasher;
-use std::hash::{Hash, Hasher};
+use std::hash::{BuildHasher, Hash, Hasher};
 
 #[cfg(any(
     all(any(target_arch = "x86", target_arch = "x86_64"), target_feature = "aes", not(miri)),
@@ -10,7 +12,7 @@ use std::hash::{Hash, Hasher};
 ))]
 fn aeshash<H: Hash>(b: &H) -> u64 {
     let build_hasher = RandomState::with_seeds(1, 2, 3, 4);
-    H::get_hash(b, &build_hasher)
+    build_hasher.hash_one(b)
 }
 #[cfg(not(any(
     all(any(target_arch = "x86", target_arch = "x86_64"), target_feature = "aes", not(miri)),
@@ -26,7 +28,7 @@ fn aeshash<H: Hash>(_b: &H) -> u64 {
 )))]
 fn fallbackhash<H: Hash>(b: &H) -> u64 {
     let build_hasher = RandomState::with_seeds(1, 2, 3, 4);
-    H::get_hash(b, &build_hasher)
+    build_hasher.hash_one(b)
 }
 #[cfg(any(
     all(any(target_arch = "x86", target_arch = "x86_64"), target_feature = "aes", not(miri)),

--- a/tests/map_tests.rs
+++ b/tests/map_tests.rs
@@ -1,4 +1,4 @@
-#![feature(build_hasher_simple_hash_one)]
+#![cfg_attr(feature = "specialize", feature(build_hasher_simple_hash_one))]
 
 use std::hash::{BuildHasher, Hash, Hasher};
 
@@ -152,9 +152,18 @@ fn check_for_collisions<H: Hash, B: BuildHasher>(build_hasher: &B, items: &[H], 
     );
 }
 
+#[cfg(feature = "specialize")]
 #[allow(unused)] // False positive
 fn hash<H: Hash, B: BuildHasher>(b: &H, build_hasher: &B) -> u64 {
     build_hasher.hash_one(b)
+}
+
+#[cfg(not(feature = "specialize"))]
+#[allow(unused)] // False positive
+fn hash<H: Hash, B: BuildHasher>(b: &H, build_hasher: &B) -> u64 {
+    let mut hasher = build_hasher.build_hasher();
+    b.hash(&mut hasher);
+    hasher.finish()
 }
 
 #[test]

--- a/tests/map_tests.rs
+++ b/tests/map_tests.rs
@@ -4,8 +4,7 @@ use std::hash::{BuildHasher, Hash, Hasher};
 
 use criterion::*;
 use fxhash::FxHasher;
-
-use ahash::{AHasher, RandomState};
+use ahash::RandomState;
 
 fn gen_word_pairs() -> Vec<String> {
     let words: Vec<_> = r#"
@@ -204,7 +203,7 @@ fn test_ahash_alias_set_construction() {
 fn ahash_vec<H: Hash>(b: &Vec<H>) -> u64 {
     let mut total: u64 = 0;
     for item in b {
-        let mut hasher = AHasher::new_with_keys(1234, 5678);
+        let mut hasher = RandomState::with_seeds(12, 34, 56, 78).build_hasher();
         item.hash(&mut hasher);
         total = total.wrapping_add(hasher.finish());
     }

--- a/tests/map_tests.rs
+++ b/tests/map_tests.rs
@@ -1,9 +1,11 @@
+#![feature(build_hasher_simple_hash_one)]
+
 use std::hash::{BuildHasher, Hash, Hasher};
 
 use criterion::*;
 use fxhash::FxHasher;
 
-use ahash::{AHasher, CallHasher, RandomState};
+use ahash::{AHasher, RandomState};
 
 fn gen_word_pairs() -> Vec<String> {
     let words: Vec<_> = r#"
@@ -152,7 +154,7 @@ fn check_for_collisions<H: Hash, B: BuildHasher>(build_hasher: &B, items: &[H], 
 
 #[allow(unused)] // False positive
 fn hash<H: Hash, B: BuildHasher>(b: &H, build_hasher: &B) -> u64 {
-    H::get_hash(b, build_hasher)
+    build_hasher.hash_one(b)
 }
 
 #[test]

--- a/tests/nopanic.rs
+++ b/tests/nopanic.rs
@@ -1,4 +1,6 @@
-use ahash::{AHasher, CallHasher, RandomState};
+#![feature(build_hasher_simple_hash_one)]
+
+use ahash::{AHasher, RandomState};
 use std::hash::BuildHasher;
 
 #[macro_use]
@@ -38,8 +40,8 @@ fn hash_test_specialize(num: i32, string: &str) -> (u64, u64) {
     let hasher1 = AHasher::new_with_keys(1, 2);
     let hasher2 = AHasher::new_with_keys(1, 2);
     (
-        i32::get_hash(&num, &SimpleBuildHasher { hasher: hasher1 }),
-        <[u8]>::get_hash(string.as_bytes(), &SimpleBuildHasher { hasher: hasher2 }),
+        SimpleBuildHasher { hasher: hasher1 }.hash_one(num),
+        SimpleBuildHasher { hasher: hasher2 }.hash_one(string.as_bytes()),
     )
 }
 
@@ -54,8 +56,8 @@ fn hash_test_random(num: i32, string: &str) -> (u64, u64) {
     let build_hasher1 = RandomState::with_seeds(1, 2, 3, 4);
     let build_hasher2 = RandomState::with_seeds(1, 2, 3, 4);
     (
-        i32::get_hash(&num, &build_hasher1),
-        <[u8]>::get_hash(string.as_bytes(), &build_hasher2),
+        build_hasher1.hash_one(&num),
+        build_hasher2.hash_one(string.as_bytes())
     )
 }
 

--- a/tests/nopanic.rs
+++ b/tests/nopanic.rs
@@ -1,7 +1,5 @@
-#![feature(build_hasher_simple_hash_one)]
-
 use ahash::{AHasher, RandomState};
-use std::hash::BuildHasher;
+use std::hash::{BuildHasher, Hash, Hasher};
 
 #[macro_use]
 extern crate no_panic;
@@ -24,6 +22,14 @@ fn hash_test_final_wrapper(num: i32, string: &str) {
 
 struct SimpleBuildHasher {
     hasher: AHasher,
+}
+
+impl SimpleBuildHasher {
+    fn hash_one<T: Hash>(&self, x: T) -> u64 where Self: Sized {
+        let mut hasher = self.build_hasher();
+        x.hash(&mut hasher);
+        hasher.finish()
+    }
 }
 
 impl BuildHasher for SimpleBuildHasher {
@@ -70,5 +76,6 @@ fn hash_test_specialize_wrapper(num: i32, string: &str) {
 fn test_no_panic() {
     hash_test_final_wrapper(2, "Foo");
     hash_test_specialize_wrapper(2, "Bar");
-    hash_test_random_wrapper(2, "Baz");
+    hash_test_random(2, "Baz");
+    hash_test_random_wrapper(2, "Bat");
 }

--- a/tests/nopanic.rs
+++ b/tests/nopanic.rs
@@ -8,8 +8,8 @@ extern crate no_panic;
 #[no_panic]
 fn hash_test_final(num: i32, string: &str) -> (u64, u64) {
     use core::hash::Hasher;
-    let mut hasher1 = AHasher::new_with_keys(1, 2);
-    let mut hasher2 = AHasher::new_with_keys(3, 4);
+    let mut hasher1 = RandomState::with_seeds(1, 2, 3, 4).build_hasher();
+    let mut hasher2 = RandomState::with_seeds(3, 4, 5, 6).build_hasher();
     hasher1.write_i32(num);
     hasher2.write(string.as_bytes());
     (hasher1.finish(), hasher2.finish())
@@ -43,8 +43,8 @@ impl BuildHasher for SimpleBuildHasher {
 #[inline(never)]
 #[no_panic]
 fn hash_test_specialize(num: i32, string: &str) -> (u64, u64) {
-    let hasher1 = AHasher::new_with_keys(1, 2);
-    let hasher2 = AHasher::new_with_keys(1, 2);
+    let hasher1 = RandomState::with_seeds(1, 2, 3, 4).build_hasher();
+    let hasher2 = RandomState::with_seeds(1, 2, 3, 4).build_hasher();
     (
         SimpleBuildHasher { hasher: hasher1 }.hash_one(num),
         SimpleBuildHasher { hasher: hasher2 }.hash_one(string.as_bytes()),


### PR DESCRIPTION
In order to address #94 and #97 changes to the public interface are needed. This incorporates this simplification as well as cleans up the public interface to take advantage of the `hash_once` function to avoid the complexity related to specialization in the 0.7 version. 
Obviously as this is backward incompatible this requires bumping the version to 0.8. 
There are no changes to the hashing algorithm.