### PR TITLE
fix AVR support by using atomic-polyfill

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,9 @@ runtime-rng = ["getrandom"]
 # If this is disabled and runtime-rng is unavailable constant keys are used.
 compile-time-rng = ["const-random"]
 
+# in case this is being used on an architecture lacking core::sync::atomic::AtomicUsize and friends
+atomic-polyfill = [ "dep:atomic-polyfill", "once_cell/atomic-polyfill"]
+
 [[bench]]
 name = "ahash"
 path = "tests/bench.rs"
@@ -72,9 +75,10 @@ getrandom = { version = "0.2.3", optional = true }
 const-random = { version = "0.1.12", optional = true }
 serde = { version = "1.0.117", optional = true }
 cfg-if = "1.0"
+atomic-polyfill = { version="1.0.1", optional=true}
 
 [target.'cfg(not(all(target_arch = "arm", target_os = "none")))'.dependencies]
-once_cell = { version = "1.8", default-features = false, features = ["unstable", "alloc"] }
+once_cell = { version = "1.13.1", default-features = false, features = ["unstable", "alloc"] }
 
 [dev-dependencies]
 no-panic = "0.1.10"

--- a/src/random_state.rs
+++ b/src/random_state.rs
@@ -23,8 +23,13 @@ cfg_if::cfg_if! {
     }
 }
 
+#[cfg(feature = "atomic-polyfill")]
+use atomic_polyfill as atomic;
+#[cfg(not(feature = "atomic-polyfill"))]
+use core::sync::atomic;
+
 use alloc::boxed::Box;
-use core::sync::atomic::{AtomicUsize, Ordering};
+use atomic::{AtomicUsize, Ordering};
 use core::any::{Any, TypeId};
 use core::fmt;
 use core::hash::BuildHasher;


### PR DESCRIPTION
Attempting to compile a project for AVR that depends on ahash fails:

```
error[E0432]: unresolved import `atomic::AtomicUsize`
  --> /home/thoth/.cargo/registry/src/github.com-1ecc6299db9ec823/once_cell-1.13.1/src/race.rs:27:14
   |
27 | use atomic::{AtomicUsize, Ordering};
   |              ^^^^^^^^^^^ no `AtomicUsize` in `sync::atomic`

error[E0432]: unresolved import `super::atomic::AtomicPtr`
```

The once_cell crate has an atomic-polyfill feature that can be enabled to solve this problem, and we adapt its technique to solve ahash's dependencies on core::sync::atomic .