### PR TITLE
patch ahash 0.7.x to support AVR using atomic-polyfill

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ std = []
 compile-time-rng = ["const-random"]
 
 # in case this is being used on an architecture lacking core::sync::atomic::AtomicUsize and friends
-atomic-polyfill = [ "dep:atomic-polyfill"]
+atomic-polyfill = [ "dep:atomic-polyfill", "once_cell/atomic-polyfill"]
 
 [[bench]]
 name = "ahash"
@@ -78,7 +78,7 @@ serde = { version = "1.0.117", optional = true }
 atomic-polyfill = { version="1.0.1", optional=true}
 
 [target.'cfg(not(all(target_arch = "arm", target_os = "none")))'.dependencies]
-once_cell = { version = "1.8", default-features = false, features = ["alloc"] }
+once_cell = { version = "1.13.1", default-features = false, features = ["alloc"] }
 
 [dev-dependencies]
 no-panic = "0.1.10"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,9 @@ std = []
 # If this is disabled and gerrandom is unavailable constant keys are used.
 compile-time-rng = ["const-random"]
 
+# in case this is being used on an architecture lacking core::sync::atomic::AtomicUsize and friends
+atomic-polyfill = [ "dep:atomic-polyfill"]
+
 [[bench]]
 name = "ahash"
 path = "tests/bench.rs"
@@ -72,6 +75,7 @@ serde = { version = "1.0.117", optional = true }
 [target.'cfg(not(any(target_os = "linux", target_os = "android", target_os = "windows", target_os = "macos", target_os = "ios", target_os = "freebsd", target_os = "openbsd", target_os = "netbsd", target_os = "dragonfly", target_os = "solaris", target_os = "illumos", target_os = "fuchsia", target_os = "redox", target_os = "cloudabi", target_os = "haiku", target_os = "vxworks", target_os = "emscripten", target_os = "wasi")))'.dependencies]
 const-random = { version = "0.1.12", optional = true }
 serde = { version = "1.0.117", optional = true }
+atomic-polyfill = { version="1.0.1", optional=true}
 
 [target.'cfg(not(all(target_arch = "arm", target_os = "none")))'.dependencies]
 once_cell = { version = "1.8", default-features = false, features = ["alloc"] }

--- a/src/random_state.rs
+++ b/src/random_state.rs
@@ -30,7 +30,12 @@ extern crate alloc;
 extern crate std as alloc;
 
 use alloc::boxed::Box;
-use core::sync::atomic::{AtomicUsize, Ordering};
+
+#[cfg(feature = "atomic-polyfill")]
+use atomic_polyfill as atomic;
+#[cfg(not(feature = "atomic-polyfill"))]
+use core::sync::atomic;
+use atomic::{AtomicUsize, Ordering};
 #[cfg(not(all(target_arch = "arm", target_os = "none")))]
 use once_cell::race::OnceBox;
 

--- a/src/random_state.rs
+++ b/src/random_state.rs
@@ -29,12 +29,12 @@ extern crate alloc;
 #[cfg(feature = "std")]
 extern crate std as alloc;
 
-use alloc::boxed::Box;
-
 #[cfg(feature = "atomic-polyfill")]
 use atomic_polyfill as atomic;
 #[cfg(not(feature = "atomic-polyfill"))]
 use core::sync::atomic;
+
+use alloc::boxed::Box;
 use atomic::{AtomicUsize, Ordering};
 #[cfg(not(all(target_arch = "arm", target_os = "none")))]
 use once_cell::race::OnceBox;


### PR DESCRIPTION
This is an alternative to #124 against the 0.7 stream.

Some crates depend on 0.7.x and switching them to 0.8.0 triggers a lot of compile errors ( rust-lang/hashbrown#356 ) .

This patch could become part of version 0.7.7 which would enable crates which depend on ahash 0.7 to compile on architectures (like AVR) which need atomic-polyfill for things like AtomicUsize and Ordering.
