### PR TITLE
Support fixed seed

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -32,6 +32,11 @@ jobs:
         with:
           command: test
           args: --no-default-features --features compile-time-rng
+      - name: check fixed-seed
+        uses: actions-rs/cargo@v1
+        with:
+          command: check
+          args: --no-default-features --features std
       - name: check
         uses: actions-rs/cargo@v1
         with:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,8 +8,8 @@
 //!
 //! aHash uses the hardware AES instruction on x86 processors to provide a keyed hash function.
 //! aHash is not a cryptographically secure hash.
-//! 
-#![cfg_attr(any(feature = "compile-time-rng", feature = "runtime-rng"), doc = r##"
+//!
+#![cfg_attr(feature = "std", doc = r##"
 # Example
 ```
 use ahash::{AHasher, RandomState};

--- a/src/random_state.rs
+++ b/src/random_state.rs
@@ -210,7 +210,6 @@ impl fmt::Debug for RandomState {
 impl RandomState {
     /// Use randomly generated keys
     #[inline]
-    #[cfg(any(feature = "compile-time-rng", feature = "runtime-rng"))]
     pub fn new() -> RandomState {
         let src = get_src();
         let fixed = get_fixed_seeds();
@@ -287,7 +286,6 @@ impl RandomState {
     }
 }
 
-#[cfg(any(feature = "compile-time-rng", feature = "runtime-rng"))]
 impl Default for RandomState {
     #[inline]
     fn default() -> Self {

--- a/src/random_state.rs
+++ b/src/random_state.rs
@@ -301,7 +301,7 @@ impl BuildHasher for RandomState {
     /// [AHasher]s that will return different hashcodes, but [Hasher]s created from the same [BuildHasher]
     /// will generate the same hashes for the same input data.
     ///
-    #[cfg_attr(any(feature = "compile-time-rng", feature = "runtime-rng"), doc = r##" # Examples
+    #[cfg_attr(feature = "std", doc = r##" # Examples
 ```
         use ahash::{AHasher, RandomState};
         use std::hash::{Hasher, BuildHasher};


### PR DESCRIPTION
Closes https://github.com/tkaitchuck/aHash/issues/126

This allows us to compile without either `runtime-rng` nor `compile-time-rng` (`--no-default-features --features std`).

Compiling without these flags will make `ahash` non-DOS-resistant.

This is meant for libraries (like `egui`) that
* Don't need DOS-resistance 
* Don't want the added dependencies and compilation times of `compile-time-rng`
* Don't want to force either `runtime-rng` or `compile-time-rng` onto the library users
* Don't want to give users confusing error messages about missing `getrandom` when compiling for wasm32