### PR TITLE
Fix benches

### DIFF
--- a/src/hash_map.rs
+++ b/src/hash_map.rs
@@ -1,6 +1,6 @@
 use std::borrow::Borrow;
-use std::collections::{hash_map, HashMap};
 use std::collections::hash_map::{IntoKeys, IntoValues};
+use std::collections::{hash_map, HashMap};
 use std::fmt::{self, Debug};
 use std::hash::{BuildHasher, Hash};
 use std::iter::FromIterator;
@@ -14,7 +14,6 @@ use serde::{
 };
 
 use crate::RandomState;
-use crate::random_state::RandomSource;
 
 /// A [`HashMap`](std::collections::HashMap) using [`RandomState`](crate::RandomState) to hash the items.
 /// (Requires the `std` feature to be enabled.)

--- a/src/hash_set.rs
+++ b/src/hash_set.rs
@@ -1,5 +1,4 @@
 use crate::RandomState;
-use crate::random_state::RandomSource;
 use std::collections::{hash_set, HashSet};
 use std::fmt::{self, Debug};
 use std::hash::{BuildHasher, Hash};

--- a/tests/bench.rs
+++ b/tests/bench.rs
@@ -73,14 +73,16 @@ fn gen_strings() -> Vec<String> {
 
 macro_rules! bench_inputs {
     ($group:ident, $hash:ident) => {
-        let size = BatchSize::NumIterations(100);
+        // Number of iterations per batch should be high enough to hide timing overhead.
+        let size = BatchSize::NumIterations(2_000);
+
         let mut rng = rand::thread_rng();
         $group.bench_function("u8", |b| b.iter_batched(|| rng.gen::<u8>(), |v| $hash(&v), size));
         $group.bench_function("u16", |b| b.iter_batched(|| rng.gen::<u16>(), |v| $hash(&v), size));
         $group.bench_function("u32", |b| b.iter_batched(|| rng.gen::<u32>(), |v| $hash(&v), size));
         $group.bench_function("u64", |b| b.iter_batched(|| rng.gen::<u64>(), |v| $hash(&v), size));
         $group.bench_function("u128", |b| b.iter_batched(|| rng.gen::<u128>(), |v| $hash(&v), size));
-        $group.bench_with_input("string", &gen_strings(), |b, s| b.iter(|| $hash(black_box(s))));
+        $group.bench_with_input("strings", &gen_strings(), |b, s| b.iter(|| $hash(black_box(s))));
     };
 }
 

--- a/tests/bench.rs
+++ b/tests/bench.rs
@@ -7,25 +7,24 @@ use rand::Rng;
 use std::collections::hash_map::DefaultHasher;
 use std::hash::{BuildHasherDefault, Hash, Hasher};
 
-mod ahash_impl {
-    pub(super) const IMPL: &str = if cfg!(any(
-        all(
-            any(target_arch = "x86", target_arch = "x86_64"),
-            target_feature = "aes",
-            not(miri),
-        ),
-        all(
-            any(target_arch = "arm", target_arch = "aarch64"),
-            any(target_feature = "aes", target_feature = "crypto"),
-            not(miri),
-            feature = "stdsimd",
-        ),
-    )) {
-        "aeshash"
-    } else {
-        "fallbackhash"
-    };
-}
+// Needs to be in sync with `src/lib.rs`
+const AHASH_IMPL: &str = if cfg!(any(
+    all(
+        any(target_arch = "x86", target_arch = "x86_64"),
+        target_feature = "aes",
+        not(miri),
+    ),
+    all(
+        any(target_arch = "arm", target_arch = "aarch64"),
+        any(target_feature = "aes", target_feature = "crypto"),
+        not(miri),
+        feature = "stdsimd",
+    ),
+)) {
+    "aeshash"
+} else {
+    "fallbackhash"
+};
 
 fn ahash<H: Hash>(b: &H) -> u64 {
     let build_hasher = RandomState::with_seeds(1, 2, 3, 4);
@@ -86,7 +85,7 @@ macro_rules! bench_inputs {
 }
 
 fn bench_ahash(c: &mut Criterion) {
-    let mut group = c.benchmark_group(ahash_impl::IMPL);
+    let mut group = c.benchmark_group(AHASH_IMPL);
     bench_inputs!(group, ahash);
 }
 


### PR DESCRIPTION
Fixes bench compilation error on M1. Seems like some of `cfg` directives were conflicting. I copied `cfg` of the implementation check from `lib.rs`.

Changed benches from hashing a const value to generating inputs at run-time. 