### PR TITLE
Proof of Concept: VAES Support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,9 @@ no-rng = []
 # in case this is being used on an architecture lacking core::sync::atomic::AtomicUsize and friends
 atomic-polyfill = [ "dep:atomic-polyfill", "once_cell/atomic-polyfill"]
 
+# Use VAES extension if possible. The hash value may be incompatible with NON-VAES targets
+vaes = []
+
 [[bench]]
 name = "ahash"
 path = "tests/bench.rs"

--- a/src/aes_hash.rs
+++ b/src/aes_hash.rs
@@ -47,6 +47,7 @@ impl AHasher {
     ///
     /// println!("Hash is {:x}!", hasher.finish());
     /// ```
+    #[allow(dead_code)]
     #[inline]
     pub(crate) fn new_with_keys(key1: u128, key2: u128) -> Self {
         let pi: [u128; 2] = PI.convert();

--- a/src/aes_hash/mod.rs
+++ b/src/aes_hash/mod.rs
@@ -379,7 +379,6 @@ impl Hasher for AHasherStr {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use crate::convert::Convert;
     use crate::operations::aesenc;
     use crate::RandomState;

--- a/src/aes_hash/vaes.rs
+++ b/src/aes_hash/vaes.rs
@@ -126,9 +126,9 @@ pub(crate) fn hash_batch_128b(data: &mut &[u8], hasher: &mut AHasher) {
     while data.len() > 128 {
         let (blocks, rest) = data.read_avx256x4();
         current[0] = current[0].aesenc(blocks[0]);
-        current[1] = current[0].aesenc(blocks[1]);
-        current[2] = current[0].aesenc(blocks[2]);
-        current[3] = current[0].aesenc(blocks[3]);
+        current[1] = current[1].aesenc(blocks[1]);
+        current[2] = current[2].aesenc(blocks[2]);
+        current[3] = current[3].aesenc(blocks[3]);
         sum[0] = sum[0].shuffle_and_add(blocks[0]);
         sum[1] = sum[1].shuffle_and_add(blocks[1]);
         sum[0] = sum[0].shuffle_and_add(blocks[2]);

--- a/src/aes_hash/vaes.rs
+++ b/src/aes_hash/vaes.rs
@@ -1,0 +1,152 @@
+use crate::convert::Convert;
+use crate::operations::{add_by_64s, aesenc};
+
+use super::AHasher;
+
+mod intrinsic {
+    #[cfg(target_arch = "x86")]
+    pub use core::arch::x86::*;
+    #[cfg(target_arch = "x86_64")]
+    pub use core::arch::x86_64::*;
+}
+
+const SHUFFLE_MASKS: [u64; 2] = [0x020a0700_0c01030e_u64, 0x050f0d08_06090b04_u64];
+
+#[derive(Copy, Clone)]
+#[repr(transparent)]
+struct Avx256(intrinsic::__m256i);
+
+trait ReadFromSliceExt {
+    fn read_last_avx256x4(&self) -> [Avx256; 4];
+    fn read_avx256x4(&self) -> ([Avx256; 4], &Self);
+}
+
+impl ReadFromSliceExt for [u8] {
+    #[inline(always)]
+    fn read_last_avx256x4(&self) -> [Avx256; 4] {
+        use intrinsic::_mm256_loadu_si256;
+        let ptr = self.as_ptr();
+        let offset = self.len() as isize - 128;
+        unsafe {
+            [
+                Avx256(_mm256_loadu_si256(ptr.offset(offset + 0 * 32) as *const _)),
+                Avx256(_mm256_loadu_si256(ptr.offset(offset + 1 * 32) as *const _)),
+                Avx256(_mm256_loadu_si256(ptr.offset(offset + 2 * 32) as *const _)),
+                Avx256(_mm256_loadu_si256(ptr.offset(offset + 3 * 32) as *const _)),
+            ]
+        }
+    }
+
+    #[inline(always)]
+    fn read_avx256x4(&self) -> ([Avx256; 4], &Self) {
+        use intrinsic::_mm256_loadu_si256;
+        let (value, rest) = self.split_at(128);
+        let ptr = value.as_ptr();
+        let array = unsafe {
+            [
+                Avx256(_mm256_loadu_si256(ptr.offset(0 * 32) as *const _)),
+                Avx256(_mm256_loadu_si256(ptr.offset(1 * 32) as *const _)),
+                Avx256(_mm256_loadu_si256(ptr.offset(2 * 32) as *const _)),
+                Avx256(_mm256_loadu_si256(ptr.offset(3 * 32) as *const _)),
+            ]
+        };
+        (array, rest)
+    }
+}
+
+// Rust is confused with targets supporting VAES without AVX512 extensions.
+// We need to manually specify the underlying intrinsic; otherwise the compiler
+// will have trouble inlining the code.
+#[allow(improper_ctypes)]
+extern "C" {
+    #[link_name = "llvm.x86.aesni.aesenc.256"]
+    fn aesenc_256(a: Avx256, round_key: Avx256) -> Avx256;
+}
+
+impl Avx256 {
+    #[inline(always)]
+    fn aesenc(self, xor: Self) -> Self {
+        unsafe { aesenc_256(self, xor) }
+    }
+    #[inline(always)]
+    fn add_by_64s(self, other: Self) -> Self {
+        use intrinsic::_mm256_add_epi64;
+        Self(unsafe { _mm256_add_epi64(self.0, other.0) })
+    }
+    #[inline(always)]
+    fn shuffle(self) -> Self {
+        use intrinsic::{_mm256_set_epi64x, _mm256_shuffle_epi8};
+        unsafe {
+            let mask = _mm256_set_epi64x(
+                SHUFFLE_MASKS[0] as _,
+                SHUFFLE_MASKS[1] as _,
+                SHUFFLE_MASKS[0] as _,
+                SHUFFLE_MASKS[1] as _,
+            );
+            Self(_mm256_shuffle_epi8(self.0, mask))
+        }
+    }
+    #[inline(always)]
+    fn shuffle_and_add(self, other: Self) -> Self {
+        self.shuffle().add_by_64s(other)
+    }
+    #[inline(always)]
+    fn from_u128(data: u128) -> Self {
+        use core::mem::transmute;
+        use intrinsic::_mm256_set_m128i;
+        Self(unsafe { _mm256_set_m128i(transmute(data), transmute(data)) })
+    }
+    #[inline(always)]
+    fn to_u128x2(self) -> [u128; 2] {
+        use core::mem::transmute;
+        use intrinsic::_mm256_extracti128_si256;
+        unsafe {
+            [
+                transmute(_mm256_extracti128_si256::<0>(self.0)),
+                transmute(_mm256_extracti128_si256::<1>(self.0)),
+            ]
+        }
+    }
+}
+
+#[inline(never)]
+pub(crate) fn hash_batch_128b(data: &mut &[u8], hasher: &mut AHasher) {
+    let tail = data.read_last_avx256x4();
+    let duplicated_key = Avx256::from_u128(hasher.key);
+    let mut current: [Avx256; 4] = [duplicated_key; 4];
+    current[0] = current[0].aesenc(tail[0]);
+    current[1] = current[1].aesenc(tail[1]);
+    current[2] = current[2].aesenc(tail[2]);
+    current[3] = current[3].aesenc(tail[3]);
+    let mut sum: [Avx256; 2] = [duplicated_key, duplicated_key];
+    sum[0] = sum[0].add_by_64s(tail[0]);
+    sum[1] = sum[1].add_by_64s(tail[1]);
+    sum[0] = sum[0].shuffle_and_add(tail[2]);
+    sum[1] = sum[1].shuffle_and_add(tail[3]);
+    while data.len() > 128 {
+        let (blocks, rest) = data.read_avx256x4();
+        current[0] = current[0].aesenc(blocks[0]);
+        current[1] = current[0].aesenc(blocks[1]);
+        current[2] = current[0].aesenc(blocks[2]);
+        current[3] = current[0].aesenc(blocks[3]);
+        sum[0] = sum[0].shuffle_and_add(blocks[0]);
+        sum[1] = sum[1].shuffle_and_add(blocks[1]);
+        sum[0] = sum[0].shuffle_and_add(blocks[2]);
+        sum[1] = sum[1].shuffle_and_add(blocks[3]);
+        *data = rest;
+    }
+    let encoded = [current[0].aesenc(current[2]), current[1].aesenc(current[3])];
+    let current = [encoded[0].to_u128x2(), encoded[1].to_u128x2()];
+    let sum = [sum[0].to_u128x2(), sum[1].to_u128x2()];
+    hasher.hash_in_2(
+        aesenc(current[0][0], current[0][1]),
+        aesenc(current[1][0], current[1][1]),
+    );
+    hasher.hash_in(
+        add_by_64s(
+            add_by_64s(sum[0][0].convert(), sum[0][1].convert()),
+            add_by_64s(sum[1][0].convert(), sum[1][1].convert()),
+        )
+            .convert(),
+    );
+}

--- a/src/hash_map.rs
+++ b/src/hash_map.rs
@@ -1,6 +1,6 @@
 use std::borrow::Borrow;
-use std::collections::{hash_map, HashMap};
 use std::collections::hash_map::{IntoKeys, IntoValues};
+use std::collections::{hash_map, HashMap};
 use std::fmt::{self, Debug};
 use std::hash::{BuildHasher, Hash};
 use std::iter::FromIterator;

--- a/src/hash_map.rs
+++ b/src/hash_map.rs
@@ -14,7 +14,6 @@ use serde::{
 };
 
 use crate::RandomState;
-use crate::random_state::RandomSource;
 
 /// A [`HashMap`](std::collections::HashMap) using [`RandomState`](crate::RandomState) to hash the items.
 /// (Requires the `std` feature to be enabled.)

--- a/src/hash_set.rs
+++ b/src/hash_set.rs
@@ -1,5 +1,4 @@
 use crate::RandomState;
-use crate::random_state::RandomSource;
 use std::collections::{hash_set, HashSet};
 use std::fmt::{self, Debug};
 use std::hash::{BuildHasher, Hash};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,10 @@
 //! But this also means that different computers or computers using different versions of ahash may observe different
 //! hash values for the same input.
 #![cfg_attr(
-    all(feature = "std", any(feature = "compile-time-rng", feature = "runtime-rng", feature = "no-rng")),
+    all(
+        feature = "std",
+        any(feature = "compile-time-rng", feature = "runtime-rng", feature = "no-rng")
+    ),
     doc = r##"
 # Basic Usage
 AHash provides an implementation of the [Hasher] trait.
@@ -97,7 +100,8 @@ Note the import of [HashMapExt]. This is needed for the constructor.
 #![cfg_attr(feature = "specialize", feature(min_specialization))]
 #![cfg_attr(feature = "specialize", feature(build_hasher_simple_hash_one))]
 #![cfg_attr(feature = "stdsimd", feature(stdsimd))]
-
+#![cfg_attr(feature = "vaes", feature(link_llvm_intrinsics))]
+#![cfg_attr(feature = "vaes", feature(simd_ffi))]
 #[macro_use]
 mod convert;
 

--- a/src/random_state.rs
+++ b/src/random_state.rs
@@ -229,7 +229,6 @@ impl fmt::Debug for RandomState {
 }
 
 impl RandomState {
-
     /// Create a new `RandomState` `BuildHasher` using random keys.
     ///
     /// Each instance will have a unique set of keys derived from [RandomSource].
@@ -316,8 +315,8 @@ impl RandomState {
     /// Calculates the hash of a single value. This provides a more convenient (and faster) way to obtain a hash:
     /// For example:
     #[cfg_attr(
-    feature = "std",
-    doc = r##" # Examples
+        feature = "std",
+        doc = r##" # Examples
 ```
     use std::hash::BuildHasher;
     use ahash::RandomState;
@@ -329,8 +328,8 @@ impl RandomState {
     )]
     /// This is similar to:
     #[cfg_attr(
-    feature = "std",
-    doc = r##" # Examples
+        feature = "std",
+        doc = r##" # Examples
 ```
     use std::hash::{BuildHasher, Hash, Hasher};
     use ahash::RandomState;
@@ -418,12 +417,11 @@ impl BuildHasher for RandomState {
         AHasher::from_random_state(self)
     }
 
-
     /// Calculates the hash of a single value. This provides a more convenient (and faster) way to obtain a hash:
     /// For example:
     #[cfg_attr(
-    feature = "std",
-    doc = r##" # Examples
+        feature = "std",
+        doc = r##" # Examples
 ```
     use std::hash::BuildHasher;
     use ahash::RandomState;
@@ -435,8 +433,8 @@ impl BuildHasher for RandomState {
     )]
     /// This is similar to:
     #[cfg_attr(
-    feature = "std",
-    doc = r##" # Examples
+        feature = "std",
+        doc = r##" # Examples
 ```
     use std::hash::{BuildHasher, Hash, Hasher};
     use ahash::RandomState;

--- a/tests/bench.rs
+++ b/tests/bench.rs
@@ -115,8 +115,12 @@ fn bench_ahash(c: &mut Criterion) {
     group.bench_with_input("u32", &U32_VALUE, |b, s| b.iter(|| black_box(aeshash(s))));
     group.bench_with_input("u64", &U64_VALUE, |b, s| b.iter(|| black_box(aeshash(s))));
     group.bench_with_input("u128", &U128_VALUE, |b, s| b.iter(|| black_box(aeshash(s))));
-    group.bench_with_input("string", &gen_strings(STRING_LENGTHS), |b, s| b.iter(|| black_box(aeshash(s))));
-    group.bench_with_input("wider-string", &gen_strings(WIDER_STRINGS_LENGTHS), |b, s| b.iter(|| black_box(aeshash(s))));
+    group.bench_with_input("string", &gen_strings(STRING_LENGTHS), |b, s| {
+        b.iter(|| black_box(aeshash(s)))
+    });
+    group.bench_with_input("wider-string", &gen_strings(WIDER_STRINGS_LENGTHS), |b, s| {
+        b.iter(|| black_box(aeshash(s)))
+    });
 }
 
 #[cfg(not(target_feature = "aes"))]
@@ -137,8 +141,12 @@ fn bench_fx(c: &mut Criterion) {
     group.bench_with_input("u32", &U32_VALUE, |b, s| b.iter(|| black_box(fxhash(s))));
     group.bench_with_input("u64", &U64_VALUE, |b, s| b.iter(|| black_box(fxhash(s))));
     group.bench_with_input("u128", &U128_VALUE, |b, s| b.iter(|| black_box(fxhash(s))));
-    group.bench_with_input("string", &gen_strings(STRING_LENGTHS), |b, s| b.iter(|| black_box(fxhash(s))));
-    group.bench_with_input("wilder-string", &gen_strings(WIDER_STRINGS_LENGTHS), |b, s| b.iter(|| black_box(fxhash(s))));
+    group.bench_with_input("string", &gen_strings(STRING_LENGTHS), |b, s| {
+        b.iter(|| black_box(fxhash(s)))
+    });
+    group.bench_with_input("wilder-string", &gen_strings(WIDER_STRINGS_LENGTHS), |b, s| {
+        b.iter(|| black_box(fxhash(s)))
+    });
 }
 
 fn bench_fnv(c: &mut Criterion) {
@@ -148,8 +156,12 @@ fn bench_fnv(c: &mut Criterion) {
     group.bench_with_input("u32", &U32_VALUE, |b, s| b.iter(|| black_box(fnvhash(s))));
     group.bench_with_input("u64", &U64_VALUE, |b, s| b.iter(|| black_box(fnvhash(s))));
     group.bench_with_input("u128", &U128_VALUE, |b, s| b.iter(|| black_box(fnvhash(s))));
-    group.bench_with_input("string", &gen_strings(STRING_LENGTHS), |b, s| b.iter(|| black_box(fnvhash(s))));
-    group.bench_with_input("wilder-string", &gen_strings(WIDER_STRINGS_LENGTHS), |b, s| b.iter(|| black_box(fnvhash(s))));
+    group.bench_with_input("string", &gen_strings(STRING_LENGTHS), |b, s| {
+        b.iter(|| black_box(fnvhash(s)))
+    });
+    group.bench_with_input("wilder-string", &gen_strings(WIDER_STRINGS_LENGTHS), |b, s| {
+        b.iter(|| black_box(fnvhash(s)))
+    });
 }
 
 fn bench_sea(c: &mut Criterion) {
@@ -159,8 +171,12 @@ fn bench_sea(c: &mut Criterion) {
     group.bench_with_input("u32", &U32_VALUE, |b, s| b.iter(|| black_box(seahash(s))));
     group.bench_with_input("u64", &U64_VALUE, |b, s| b.iter(|| black_box(seahash(s))));
     group.bench_with_input("u128", &U128_VALUE, |b, s| b.iter(|| black_box(seahash(s))));
-    group.bench_with_input("string", &gen_strings(STRING_LENGTHS), |b, s| b.iter(|| black_box(seahash(s))));
-    group.bench_with_input("wilder-string", &gen_strings(WIDER_STRINGS_LENGTHS), |b, s| b.iter(|| black_box(seahash(s))));
+    group.bench_with_input("string", &gen_strings(STRING_LENGTHS), |b, s| {
+        b.iter(|| black_box(seahash(s)))
+    });
+    group.bench_with_input("wilder-string", &gen_strings(WIDER_STRINGS_LENGTHS), |b, s| {
+        b.iter(|| black_box(seahash(s)))
+    });
 }
 
 fn bench_sip(c: &mut Criterion) {
@@ -170,8 +186,12 @@ fn bench_sip(c: &mut Criterion) {
     group.bench_with_input("u32", &U32_VALUE, |b, s| b.iter(|| black_box(siphash(s))));
     group.bench_with_input("u64", &U64_VALUE, |b, s| b.iter(|| black_box(siphash(s))));
     group.bench_with_input("u128", &U128_VALUE, |b, s| b.iter(|| black_box(siphash(s))));
-    group.bench_with_input("string", &gen_strings(STRING_LENGTHS), |b, s| b.iter(|| black_box(siphash(s))));
-    group.bench_with_input("wilder-string", &gen_strings(WIDER_STRINGS_LENGTHS), |b, s| b.iter(|| black_box(siphash(s))));
+    group.bench_with_input("string", &gen_strings(STRING_LENGTHS), |b, s| {
+        b.iter(|| black_box(siphash(s)))
+    });
+    group.bench_with_input("wilder-string", &gen_strings(WIDER_STRINGS_LENGTHS), |b, s| {
+        b.iter(|| black_box(siphash(s)))
+    });
 }
 
 #[allow(dead_code)]

--- a/tests/bench.rs
+++ b/tests/bench.rs
@@ -54,6 +54,7 @@ fn fallbackhash<H: Hash>(b: &H) -> u64 {
         feature = "stdsimd"
     )
 ))]
+#[allow(dead_code)]
 fn fallbackhash<H: Hash>(_b: &H) -> u64 {
     panic!("aes must be disabled")
 }
@@ -82,10 +83,12 @@ fn seahash<H: Hash>(b: &H) -> u64 {
     hasher.finish()
 }
 
-const STRING_LENGTHS: [u32; 12] = [1, 3, 4, 7, 8, 15, 16, 24, 33, 68, 132, 1024];
+const WIDER_STRINGS_LENGTHS: &'static [u32] = &[1, 64, 1024, 4096, 5261, 16384, 19997];
 
-fn gen_strings() -> Vec<String> {
-    STRING_LENGTHS
+const STRING_LENGTHS: &'static [u32] = &[1, 3, 4, 7, 8, 15, 16, 24, 33, 68, 132, 1024];
+
+fn gen_strings(lengths: &[u32]) -> Vec<String> {
+    lengths
         .iter()
         .map(|len| {
             let mut string = String::default();
@@ -112,7 +115,8 @@ fn bench_ahash(c: &mut Criterion) {
     group.bench_with_input("u32", &U32_VALUE, |b, s| b.iter(|| black_box(aeshash(s))));
     group.bench_with_input("u64", &U64_VALUE, |b, s| b.iter(|| black_box(aeshash(s))));
     group.bench_with_input("u128", &U128_VALUE, |b, s| b.iter(|| black_box(aeshash(s))));
-    group.bench_with_input("string", &gen_strings(), |b, s| b.iter(|| black_box(aeshash(s))));
+    group.bench_with_input("string", &gen_strings(STRING_LENGTHS), |b, s| b.iter(|| black_box(aeshash(s))));
+    group.bench_with_input("wider-string", &gen_strings(WIDER_STRINGS_LENGTHS), |b, s| b.iter(|| black_box(aeshash(s))));
 }
 
 #[cfg(not(target_feature = "aes"))]
@@ -133,7 +137,8 @@ fn bench_fx(c: &mut Criterion) {
     group.bench_with_input("u32", &U32_VALUE, |b, s| b.iter(|| black_box(fxhash(s))));
     group.bench_with_input("u64", &U64_VALUE, |b, s| b.iter(|| black_box(fxhash(s))));
     group.bench_with_input("u128", &U128_VALUE, |b, s| b.iter(|| black_box(fxhash(s))));
-    group.bench_with_input("string", &gen_strings(), |b, s| b.iter(|| black_box(fxhash(s))));
+    group.bench_with_input("string", &gen_strings(STRING_LENGTHS), |b, s| b.iter(|| black_box(fxhash(s))));
+    group.bench_with_input("wilder-string", &gen_strings(WIDER_STRINGS_LENGTHS), |b, s| b.iter(|| black_box(fxhash(s))));
 }
 
 fn bench_fnv(c: &mut Criterion) {
@@ -143,7 +148,8 @@ fn bench_fnv(c: &mut Criterion) {
     group.bench_with_input("u32", &U32_VALUE, |b, s| b.iter(|| black_box(fnvhash(s))));
     group.bench_with_input("u64", &U64_VALUE, |b, s| b.iter(|| black_box(fnvhash(s))));
     group.bench_with_input("u128", &U128_VALUE, |b, s| b.iter(|| black_box(fnvhash(s))));
-    group.bench_with_input("string", &gen_strings(), |b, s| b.iter(|| black_box(fnvhash(s))));
+    group.bench_with_input("string", &gen_strings(STRING_LENGTHS), |b, s| b.iter(|| black_box(fnvhash(s))));
+    group.bench_with_input("wilder-string", &gen_strings(WIDER_STRINGS_LENGTHS), |b, s| b.iter(|| black_box(fnvhash(s))));
 }
 
 fn bench_sea(c: &mut Criterion) {
@@ -153,7 +159,8 @@ fn bench_sea(c: &mut Criterion) {
     group.bench_with_input("u32", &U32_VALUE, |b, s| b.iter(|| black_box(seahash(s))));
     group.bench_with_input("u64", &U64_VALUE, |b, s| b.iter(|| black_box(seahash(s))));
     group.bench_with_input("u128", &U128_VALUE, |b, s| b.iter(|| black_box(seahash(s))));
-    group.bench_with_input("string", &gen_strings(), |b, s| b.iter(|| black_box(seahash(s))));
+    group.bench_with_input("string", &gen_strings(STRING_LENGTHS), |b, s| b.iter(|| black_box(seahash(s))));
+    group.bench_with_input("wilder-string", &gen_strings(WIDER_STRINGS_LENGTHS), |b, s| b.iter(|| black_box(seahash(s))));
 }
 
 fn bench_sip(c: &mut Criterion) {
@@ -163,9 +170,11 @@ fn bench_sip(c: &mut Criterion) {
     group.bench_with_input("u32", &U32_VALUE, |b, s| b.iter(|| black_box(siphash(s))));
     group.bench_with_input("u64", &U64_VALUE, |b, s| b.iter(|| black_box(siphash(s))));
     group.bench_with_input("u128", &U128_VALUE, |b, s| b.iter(|| black_box(siphash(s))));
-    group.bench_with_input("string", &gen_strings(), |b, s| b.iter(|| black_box(siphash(s))));
+    group.bench_with_input("string", &gen_strings(STRING_LENGTHS), |b, s| b.iter(|| black_box(siphash(s))));
+    group.bench_with_input("wilder-string", &gen_strings(WIDER_STRINGS_LENGTHS), |b, s| b.iter(|| black_box(siphash(s))));
 }
 
+#[allow(dead_code)]
 fn bench_map(c: &mut Criterion) {
     #[cfg(feature = "std")]
     {


### PR DESCRIPTION
The idea is to add use VAES instruction to scan wider length each loop iteration.
(I also tested scan the same length per loop with less instruction, but it does not speed up at all).

We can gain 100% speed up.

Without `VAES`
```
aeshash/string          time:   [59.425 ns 59.475 ns 59.523 ns]                           
aeshash/wider-string    time:   [1.2053 µs 1.2062 µs 1.2075 µs]   
```

With `VAES`:
```
aeshash/string          time:   [52.435 ns 52.511 ns 52.604 ns]                           
                        change: [-11.669% -11.523% -11.383%] (p = 0.00 < 0.05)
                        Performance has improved.
aeshash/wider-string    time:   [531.93 ns 532.18 ns 532.47 ns]                                  
                        change: [-55.856% -55.809% -55.765%] (p = 0.00 < 0.05)
                        Performance has improved.
```

-----------------------

**Notice:**
- `aeshash/wider-string` is same as `aeshash/string` except that its lengths set has larger data point.
- `vaes` passed all quality tests but its hash value may not be compatible with non-aes targets.

