### PR TITLE
Add missing #[inline] to get_fixed_seeds

### DIFF
--- a/src/random_state.rs
+++ b/src/random_state.rs
@@ -103,6 +103,7 @@ cfg_if::cfg_if! {
             &RAND
         }
     } else {
+        #[inline]
         fn get_fixed_seeds() -> &'static [[u64; 4]; 2] {
             &[PI, PI2]
         }


### PR DESCRIPTION
This was missing on the fallback implementation that uses compile-time constants, which is the default implementation used by hashbrown.