### PR TITLE
Expose specialized versions of `AHasher` through `specialized-hashers` feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ bench = true
 doc = true
 
 [features]
-default = ["std", "runtime-rng"]
+default = ["std", "runtime-rng", "specialized-hashers"]
 
 # Enabling this will enable `AHashMap` and `AHashSet`.
 std = []
@@ -42,6 +42,9 @@ no-rng = []
 
 # in case this is being used on an architecture lacking core::sync::atomic::AtomicUsize and friends
 atomic-polyfill = [ "dep:atomic-polyfill", "once_cell/atomic-polyfill"]
+
+# expose specialized `AHasherU64`, `AHasherFixed`, and `AHasherStr`
+specialized-hashers = []
 
 [[bench]]
 name = "ahash"

--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ map.insert(56, 78);
 The aHash package has the following flags:
 * `std`: This enables features which require the standard library. (On by default) This includes providing the utility classes `AHashMap` and `AHashSet`.
 * `serde`: Enables `serde` support for the utility classes `AHashMap` and `AHashSet`.
+* `specialized-hashers`: Exposes `AHasherU64`, `AHasherFixed`, and `AHasherStr` (as well as `BuildAHasherU64`, `BuildAHasherFixed`, and `BuildAHasherStr`),
+which are specialized versions of `AHasher` for particular types of keys providing higher performance when a particular type of key is used.
 * `runtime-rng`: To obtain a seed for Hashers will obtain randomness from the operating system. (On by default)
 This is done using the [getrandom](https://github.com/rust-random/getrandom) crate.
 * `compile-time-rng`: For OS targets without access to a random number generator, `compile-time-rng` provides an alternative.

--- a/src/aes_hash.rs
+++ b/src/aes_hash.rs
@@ -213,14 +213,16 @@ impl Hasher for AHasher {
     }
 }
 
-#[cfg(feature = "specialize")]
-pub(crate) struct AHasherU64 {
+/// A specialized hasher for only primitives <= 64 bits.
+/// 
+/// Can be built with [`BuildAHasherU64`][crate::BuildAHasherU64]
+#[cfg(any(feature = "specialize", feature = "specialized-hashers"))]
+pub struct AHasherU64 {
     pub(crate) buffer: u64,
     pub(crate) pad: u64,
 }
 
-/// A specialized hasher for only primitives under 64 bits.
-#[cfg(feature = "specialize")]
+#[cfg(any(feature = "specialize", feature = "specialized-hashers"))]
 impl Hasher for AHasherU64 {
     #[inline]
     fn finish(&self) -> u64 {
@@ -264,11 +266,13 @@ impl Hasher for AHasherU64 {
     }
 }
 
-#[cfg(feature = "specialize")]
-pub(crate) struct AHasherFixed(pub AHasher);
-
 /// A specialized hasher for fixed size primitives larger than 64 bits.
-#[cfg(feature = "specialize")]
+/// 
+/// Can be built with [`BuildAHasherFixed`][crate::BuildAHasherFixed]
+#[cfg(any(feature = "specialize", feature = "specialized-hashers"))]
+pub struct AHasherFixed(pub(crate) AHasher);
+
+#[cfg(any(feature = "specialize", feature = "specialized-hashers"))]
 impl Hasher for AHasherFixed {
     #[inline]
     fn finish(&self) -> u64 {
@@ -311,12 +315,15 @@ impl Hasher for AHasherFixed {
     }
 }
 
-#[cfg(feature = "specialize")]
-pub(crate) struct AHasherStr(pub AHasher);
+/// A specialized hasher for strings.
+/// 
+/// Note that other types don't panic because the hash impl for String tacks on an unneeded call. (As does vec)
+/// 
+/// Can be built with [`BuildAHasherStr`][crate::BuildAHasherStr]
+#[cfg(any(feature = "specialize", feature = "specialized-hashers"))]
+pub struct AHasherStr(pub(crate) AHasher);
 
-/// A specialized hasher for strings
-/// Note that the other types don't panic because the hash impl for String tacks on an unneeded call. (As does vec)
-#[cfg(feature = "specialize")]
+#[cfg(any(feature = "specialize", feature = "specialized-hashers"))]
 impl Hasher for AHasherStr {
     #[inline]
     fn finish(&self) -> u64 {

--- a/src/fallback_hash.rs
+++ b/src/fallback_hash.rs
@@ -115,7 +115,7 @@ impl AHasher {
     }
 
     #[inline]
-    #[cfg(feature = "specialize")]
+    #[cfg(any(feature = "specialize", feature = "specialized-hashers"))]
     fn short_finish(&self) -> u64 {
         self.buffer.wrapping_add(self.pad)
     }
@@ -199,14 +199,16 @@ impl Hasher for AHasher {
     }
 }
 
-#[cfg(feature = "specialize")]
-pub(crate) struct AHasherU64 {
+/// A specialized hasher for only primitives <= 64 bits.
+/// 
+/// Can be built with [`BuildAHasherU64`][crate::BuildAHasherU64]
+#[cfg(any(feature = "specialize", feature = "specialized-hashers"))]
+pub struct AHasherU64 {
     pub(crate) buffer: u64,
     pub(crate) pad: u64,
 }
 
-/// A specialized hasher for only primitives under 64 bits.
-#[cfg(feature = "specialize")]
+#[cfg(any(feature = "specialize", feature = "specialized-hashers"))]
 impl Hasher for AHasherU64 {
     #[inline]
     fn finish(&self) -> u64 {
@@ -250,11 +252,13 @@ impl Hasher for AHasherU64 {
     }
 }
 
-#[cfg(feature = "specialize")]
-pub(crate) struct AHasherFixed(pub AHasher);
-
 /// A specialized hasher for fixed size primitives larger than 64 bits.
-#[cfg(feature = "specialize")]
+/// 
+/// Can be built with [`BuildAHasherFixed`][crate::BuildAHasherFixed]
+#[cfg(any(feature = "specialize", feature = "specialized-hashers"))]
+pub struct AHasherFixed(pub(crate) AHasher);
+
+#[cfg(any(feature = "specialize", feature = "specialized-hashers"))]
 impl Hasher for AHasherFixed {
     #[inline]
     fn finish(&self) -> u64 {
@@ -297,12 +301,15 @@ impl Hasher for AHasherFixed {
     }
 }
 
-#[cfg(feature = "specialize")]
-pub(crate) struct AHasherStr(pub AHasher);
+/// A specialized hasher for strings.
+/// 
+/// Note that other types don't panic because the hash impl for String tacks on an unneeded call. (As does vec)
+/// 
+/// Can be built with [`BuildAHasherStr`][crate::BuildAHasherStr]
+#[cfg(any(feature = "specialize", feature = "specialized-hashers"))]
+pub struct AHasherStr(pub(crate) AHasher);
 
-/// A specialized hasher for a single string
-/// Note that the other types don't panic because the hash impl for String tacks on an unneeded call. (As does vec)
-#[cfg(feature = "specialize")]
+#[cfg(any(feature = "specialize", feature = "specialized-hashers"))]
 impl Hasher for AHasherStr {
     #[inline]
     fn finish(&self) -> u64 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -144,6 +144,12 @@ pub mod random_state;
 mod specialize;
 
 pub use crate::random_state::RandomState;
+#[cfg(feature = "specialized-hashers")]
+pub use crate::random_state::BuildAHasherU64;
+#[cfg(feature = "specialized-hashers")]
+pub use crate::random_state::BuildAHasherFixed;
+#[cfg(feature = "specialized-hashers")]
+pub use crate::random_state::BuildAHasherStr;
 
 use core::hash::BuildHasher;
 use core::hash::Hash;


### PR DESCRIPTION
This adds a `specialized-hashers` feature which exposes the existing specialized hasher implementations that were under the nightly-only specialization feature for manual use. To support this, also adds `BuildAHasherU64`, `BuildAHasherFixed`, and `BuildAHasherStr` types that can be used in places that expect `BuildHasher`s and which leverage existing infrastructure to create these specialized versions of hashers.