### PR TITLE
Change update function to use decryption rather than encryption.

### DIFF
--- a/smhasher/ahash-cbindings/src/lib.rs
+++ b/smhasher/ahash-cbindings/src/lib.rs
@@ -1,5 +1,3 @@
-#![feature(build_hasher_simple_hash_one)]
-
 use ahash::*;
 use core::slice;
 use std::hash::{BuildHasher};

--- a/smhasher/ahashOutput.txt
+++ b/smhasher/ahashOutput.txt
@@ -65,134 +65,134 @@ Running fast HashMapTest: 86.785 cycles/op (3.2 stdv)  ....... PASS
 
 [[[ Avalanche Tests ]]]
 
-Testing   24-bit keys ->  64-bit hashes, 300000 reps.......... worst bias is 0.634667%
-Testing   32-bit keys ->  64-bit hashes, 300000 reps.......... worst bias is 0.600667%
-Testing   40-bit keys ->  64-bit hashes, 300000 reps.......... worst bias is 0.627333%
-Testing   48-bit keys ->  64-bit hashes, 300000 reps.......... worst bias is 0.656667%
-Testing   56-bit keys ->  64-bit hashes, 300000 reps.......... worst bias is 0.599333%
-Testing   64-bit keys ->  64-bit hashes, 300000 reps.......... worst bias is 0.690667%
-Testing   72-bit keys ->  64-bit hashes, 300000 reps.......... worst bias is 0.812667%
-Testing   80-bit keys ->  64-bit hashes, 300000 reps.......... worst bias is 0.678000%
-Testing   96-bit keys ->  64-bit hashes, 300000 reps.......... worst bias is 0.670000%
-Testing  112-bit keys ->  64-bit hashes, 300000 reps.......... worst bias is 0.728667%
-Testing  128-bit keys ->  64-bit hashes, 300000 reps.......... worst bias is 0.717333%
-Testing  160-bit keys ->  64-bit hashes, 300000 reps.......... worst bias is 0.681333%
-Testing  512-bit keys ->  64-bit hashes, 300000 reps.......... worst bias is 0.922000%
-Testing 1024-bit keys ->  64-bit hashes, 300000 reps.......... worst bias is 0.740000%
+Testing   24-bit keys ->  64-bit hashes, 300000 reps.......... worst bias is 0.626000%
+Testing   32-bit keys ->  64-bit hashes, 300000 reps.......... worst bias is 0.587333%
+Testing   40-bit keys ->  64-bit hashes, 300000 reps.......... worst bias is 0.720667%
+Testing   48-bit keys ->  64-bit hashes, 300000 reps.......... worst bias is 0.648667%
+Testing   56-bit keys ->  64-bit hashes, 300000 reps.......... worst bias is 0.687333%
+Testing   64-bit keys ->  64-bit hashes, 300000 reps.......... worst bias is 0.652667%
+Testing   72-bit keys ->  64-bit hashes, 300000 reps.......... worst bias is 0.724000%
+Testing   80-bit keys ->  64-bit hashes, 300000 reps.......... worst bias is 0.824000%
+Testing   96-bit keys ->  64-bit hashes, 300000 reps.......... worst bias is 0.698667%
+Testing  112-bit keys ->  64-bit hashes, 300000 reps.......... worst bias is 0.697333%
+Testing  128-bit keys ->  64-bit hashes, 300000 reps.......... worst bias is 0.692000%
+Testing  160-bit keys ->  64-bit hashes, 300000 reps.......... worst bias is 0.748667%
+Testing  512-bit keys ->  64-bit hashes, 300000 reps.......... worst bias is 0.754667%
+Testing 1024-bit keys ->  64-bit hashes, 300000 reps.......... worst bias is 0.821333%
 
 [[[ Keyset 'Sparse' Tests ]]]
 
 Keyset 'Sparse' - 16-bit keys with up to 9 bits set - 50643 keys
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
 Testing collisions (high 32-bit) - Expected          0.3, actual      0 (0.00x)
-Testing collisions (high 19-25 bits) - Worst is 19 bits: 2369/2368 (1.00x)
-Testing collisions (low  32-bit) - Expected          0.3, actual      1 (3.35x) (1) !
-Testing collisions (low  19-25 bits) - Worst is 25 bits: 46/38 (1.20x)
-Testing distribution - Worst bias is the 13-bit window at bit 24 - 0.505%
+Testing collisions (high 19-25 bits) - Worst is 20 bits: 1227/1203 (1.02x)
+Testing collisions (low  32-bit) - Expected          0.3, actual      0 (0.00x)
+Testing collisions (low  19-25 bits) - Worst is 25 bits: 43/38 (1.13x)
+Testing distribution - Worst bias is the 13-bit window at bit 20 - 0.620%
 
 Keyset 'Sparse' - 24-bit keys with up to 8 bits set - 1271626 keys
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected        188.2, actual    171 (0.91x)
-Testing collisions (high 24-35 bits) - Worst is 28 bits: 3050/3007 (1.01x)
-Testing collisions (low  32-bit) - Expected        188.2, actual    193 (1.03x) (5)
-Testing collisions (low  24-35 bits) - Worst is 30 bits: 774/752 (1.03x)
-Testing distribution - Worst bias is the 17-bit window at bit 51 - 0.087%
+Testing collisions (high 32-bit) - Expected        188.2, actual    203 (1.08x) (15)
+Testing collisions (high 24-35 bits) - Worst is 32 bits: 203/188 (1.08x)
+Testing collisions (low  32-bit) - Expected        188.2, actual    203 (1.08x) (15)
+Testing collisions (low  24-35 bits) - Worst is 33 bits: 110/94 (1.17x)
+Testing distribution - Worst bias is the 17-bit window at bit 48 - 0.116%
 
 Keyset 'Sparse' - 32-bit keys with up to 7 bits set - 4514873 keys
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected       2372.2, actual   2423 (1.02x) (51)
-Testing collisions (high 25-38 bits) - Worst is 36 bits: 162/148 (1.09x)
-Testing collisions (low  32-bit) - Expected       2372.2, actual   2312 (0.97x)
-Testing collisions (low  25-38 bits) - Worst is 38 bits: 42/37 (1.13x)
-Testing distribution - Worst bias is the 19-bit window at bit 19 - 0.040%
+Testing collisions (high 32-bit) - Expected       2372.2, actual   2445 (1.03x) (73)
+Testing collisions (high 25-38 bits) - Worst is 34 bits: 642/593 (1.08x)
+Testing collisions (low  32-bit) - Expected       2372.2, actual   2392 (1.01x) (20)
+Testing collisions (low  25-38 bits) - Worst is 32 bits: 2392/2372 (1.01x)
+Testing distribution - Worst bias is the 19-bit window at bit 46 - 0.050%
 
 Keyset 'Sparse' - 40-bit keys with up to 6 bits set - 4598479 keys
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected       2460.8, actual   2483 (1.01x) (23)
-Testing collisions (high 25-38 bits) - Worst is 38 bits: 54/38 (1.40x)
-Testing collisions (low  32-bit) - Expected       2460.8, actual   2444 (0.99x) (-16)
-Testing collisions (low  25-38 bits) - Worst is 38 bits: 43/38 (1.12x)
-Testing distribution - Worst bias is the 19-bit window at bit 56 - 0.074%
+Testing collisions (high 32-bit) - Expected       2460.8, actual   2585 (1.05x) (125)
+Testing collisions (high 25-38 bits) - Worst is 38 bits: 44/38 (1.14x)
+Testing collisions (low  32-bit) - Expected       2460.8, actual   2462 (1.00x) (2)
+Testing collisions (low  25-38 bits) - Worst is 37 bits: 86/76 (1.12x)
+Testing distribution - Worst bias is the 19-bit window at bit 32 - 0.039%
 
 Keyset 'Sparse' - 48-bit keys with up to 6 bits set - 14196869 keys
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected      23437.8, actual  23188 (0.99x) (-249)
-Testing collisions (high 27-42 bits) - Worst is 30 bits: 93748/93442 (1.00x)
-Testing collisions (low  32-bit) - Expected      23437.8, actual  23337 (1.00x) (-100)
-Testing collisions (low  27-42 bits) - Worst is 39 bits: 187/183 (1.02x)
-Testing distribution - Worst bias is the 20-bit window at bit 30 - 0.021%
+Testing collisions (high 32-bit) - Expected      23437.8, actual  23507 (1.00x) (70)
+Testing collisions (high 27-42 bits) - Worst is 42 bits: 25/22 (1.09x)
+Testing collisions (low  32-bit) - Expected      23437.8, actual  23406 (1.00x) (-31)
+Testing collisions (low  27-42 bits) - Worst is 42 bits: 32/22 (1.40x)
+Testing distribution - Worst bias is the 20-bit window at bit 21 - 0.019%
 
 Keyset 'Sparse' - 56-bit keys with up to 5 bits set - 4216423 keys
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected       2069.0, actual   2107 (1.02x) (39)
-Testing collisions (high 25-38 bits) - Worst is 36 bits: 147/129 (1.14x)
-Testing collisions (low  32-bit) - Expected       2069.0, actual   2111 (1.02x) (43)
-Testing collisions (low  25-38 bits) - Worst is 32 bits: 2111/2068 (1.02x)
-Testing distribution - Worst bias is the 18-bit window at bit 57 - 0.046%
+Testing collisions (high 32-bit) - Expected       2069.0, actual   2109 (1.02x) (41)
+Testing collisions (high 25-38 bits) - Worst is 38 bits: 41/32 (1.27x)
+Testing collisions (low  32-bit) - Expected       2069.0, actual   2063 (1.00x) (-5)
+Testing collisions (low  25-38 bits) - Worst is 29 bits: 16692/16513 (1.01x)
+Testing distribution - Worst bias is the 19-bit window at bit 24 - 0.070%
 
 Keyset 'Sparse' - 64-bit keys with up to 5 bits set - 8303633 keys
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected       8021.7, actual   7994 (1.00x) (-27)
-Testing collisions (high 26-40 bits) - Worst is 39 bits: 70/62 (1.12x)
-Testing collisions (low  32-bit) - Expected       8021.7, actual   8171 (1.02x) (150)
-Testing collisions (low  26-40 bits) - Worst is 39 bits: 66/62 (1.05x)
-Testing distribution - Worst bias is the 20-bit window at bit 32 - 0.044%
+Testing collisions (high 32-bit) - Expected       8021.7, actual   7956 (0.99x) (-65)
+Testing collisions (high 26-40 bits) - Worst is 40 bits: 33/31 (1.05x)
+Testing collisions (low  32-bit) - Expected       8021.7, actual   8042 (1.00x) (21)
+Testing collisions (low  26-40 bits) - Worst is 33 bits: 4038/4012 (1.01x)
+Testing distribution - Worst bias is the 20-bit window at bit 26 - 0.025%
 
 Keyset 'Sparse' - 72-bit keys with up to 5 bits set - 15082603 keys
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected      26451.8, actual  26737 (1.01x) (286)
-Testing collisions (high 27-42 bits) - Worst is 37 bits: 854/827 (1.03x)
-Testing collisions (low  32-bit) - Expected      26451.8, actual  26464 (1.00x) (13)
-Testing collisions (low  27-42 bits) - Worst is 40 bits: 123/103 (1.19x)
-Testing distribution - Worst bias is the 20-bit window at bit 26 - 0.018%
+Testing collisions (high 32-bit) - Expected      26451.8, actual  26636 (1.01x) (185)
+Testing collisions (high 27-42 bits) - Worst is 42 bits: 35/25 (1.35x)
+Testing collisions (low  32-bit) - Expected      26451.8, actual  26728 (1.01x) (277)
+Testing collisions (low  27-42 bits) - Worst is 37 bits: 874/827 (1.06x)
+Testing distribution - Worst bias is the 20-bit window at bit  7 - 0.029%
 
 Keyset 'Sparse' - 96-bit keys with up to 4 bits set - 3469497 keys
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected       1401.0, actual   1387 (0.99x) (-13)
-Testing collisions (high 25-38 bits) - Worst is 35 bits: 190/175 (1.08x)
-Testing collisions (low  32-bit) - Expected       1401.0, actual   1415 (1.01x) (15)
-Testing collisions (low  25-38 bits) - Worst is 38 bits: 33/21 (1.51x)
-Testing distribution - Worst bias is the 19-bit window at bit 22 - 0.072%
+Testing collisions (high 32-bit) - Expected       1401.0, actual   1415 (1.01x) (15)
+Testing collisions (high 25-38 bits) - Worst is 38 bits: 23/21 (1.05x)
+Testing collisions (low  32-bit) - Expected       1401.0, actual   1407 (1.00x) (7)
+Testing collisions (low  25-38 bits) - Worst is 35 bits: 209/175 (1.19x)
+Testing distribution - Worst bias is the 19-bit window at bit 29 - 0.092%
 
 Keyset 'Sparse' - 160-bit keys with up to 4 bits set - 26977161 keys
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected      84546.1, actual  84950 (1.00x) (404)
-Testing collisions (high 28-44 bits) - Worst is 44 bits: 28/20 (1.35x)
-Testing collisions (low  32-bit) - Expected      84546.1, actual  84446 (1.00x) (-100)
-Testing collisions (low  28-44 bits) - Worst is 41 bits: 174/165 (1.05x)
-Testing distribution - Worst bias is the 20-bit window at bit 40 - 0.011%
+Testing collisions (high 32-bit) - Expected      84546.1, actual  84863 (1.00x) (317)
+Testing collisions (high 28-44 bits) - Worst is 44 bits: 23/20 (1.11x)
+Testing collisions (low  32-bit) - Expected      84546.1, actual  84657 (1.00x) (111)
+Testing collisions (low  28-44 bits) - Worst is 34 bits: 21448/21169 (1.01x)
+Testing distribution - Worst bias is the 20-bit window at bit 48 - 0.011%
 
 Keyset 'Sparse' - 256-bit keys with up to 3 bits set - 2796417 keys
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected        910.2, actual    973 (1.07x) (63)
-Testing collisions (high 25-37 bits) - Worst is 35 bits: 130/113 (1.14x)
-Testing collisions (low  32-bit) - Expected        910.2, actual    962 (1.06x) (52)
-Testing collisions (low  25-37 bits) - Worst is 36 bits: 68/56 (1.20x)
-Testing distribution - Worst bias is the 19-bit window at bit 27 - 0.108%
+Testing collisions (high 32-bit) - Expected        910.2, actual    950 (1.04x) (40)
+Testing collisions (high 25-37 bits) - Worst is 37 bits: 34/28 (1.20x)
+Testing collisions (low  32-bit) - Expected        910.2, actual    840 (0.92x)
+Testing collisions (low  25-37 bits) - Worst is 26 bits: 57659/57462 (1.00x)
+Testing distribution - Worst bias is the 19-bit window at bit 15 - 0.108%
 
 Keyset 'Sparse' - 512-bit keys with up to 3 bits set - 22370049 keys
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected      58155.4, actual  58209 (1.00x) (54)
-Testing collisions (high 28-43 bits) - Worst is 33 bits: 29243/29102 (1.00x)
-Testing collisions (low  32-bit) - Expected      58155.4, actual  58026 (1.00x) (-129)
-Testing collisions (low  28-43 bits) - Worst is 43 bits: 33/28 (1.16x)
-Testing distribution - Worst bias is the 20-bit window at bit 54 - 0.011%
+Testing collisions (high 32-bit) - Expected      58155.4, actual  58002 (1.00x) (-153)
+Testing collisions (high 28-43 bits) - Worst is 39 bits: 470/455 (1.03x)
+Testing collisions (low  32-bit) - Expected      58155.4, actual  58146 (1.00x) (-9)
+Testing collisions (low  28-43 bits) - Worst is 34 bits: 14592/14557 (1.00x)
+Testing distribution - Worst bias is the 20-bit window at bit 39 - 0.011%
 
 Keyset 'Sparse' - 1024-bit keys with up to 2 bits set - 524801 keys
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected         32.1, actual     31 (0.97x)
-Testing collisions (high 22-32 bits) - Worst is 28 bits: 569/512 (1.11x)
-Testing collisions (low  32-bit) - Expected         32.1, actual     24 (0.75x)
-Testing collisions (low  22-32 bits) - Worst is 29 bits: 285/256 (1.11x)
-Testing distribution - Worst bias is the 16-bit window at bit 32 - 0.224%
+Testing collisions (high 32-bit) - Expected         32.1, actual     35 (1.09x) (3)
+Testing collisions (high 22-32 bits) - Worst is 32 bits: 35/32 (1.09x)
+Testing collisions (low  32-bit) - Expected         32.1, actual     38 (1.19x) (6)
+Testing collisions (low  22-32 bits) - Worst is 31 bits: 78/64 (1.22x)
+Testing distribution - Worst bias is the 16-bit window at bit  5 - 0.137%
 
 Keyset 'Sparse' - 2048-bit keys with up to 2 bits set - 2098177 keys
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected        512.4, actual    506 (0.99x) (-6)
-Testing collisions (high 24-36 bits) - Worst is 34 bits: 144/128 (1.12x)
-Testing collisions (low  32-bit) - Expected        512.4, actual    510 (1.00x) (-2)
-Testing collisions (low  24-36 bits) - Worst is 28 bits: 8200/8178 (1.00x)
-Testing distribution - Worst bias is the 18-bit window at bit 49 - 0.101%
+Testing collisions (high 32-bit) - Expected        512.4, actual    521 (1.02x) (9)
+Testing collisions (high 24-36 bits) - Worst is 32 bits: 521/512 (1.02x)
+Testing collisions (low  32-bit) - Expected        512.4, actual    541 (1.06x) (29)
+Testing collisions (low  24-36 bits) - Worst is 31 bits: 1111/1024 (1.08x)
+Testing distribution - Worst bias is the 18-bit window at bit  6 - 0.070%
 
 
 [[[ Keyset 'Permutation' Tests ]]]
@@ -200,151 +200,151 @@ Testing distribution - Worst bias is the 18-bit window at bit 49 - 0.101%
 Combination Lowbits Tests:
 Keyset 'Combination' - up to 7 blocks from a set of 8 - 2396744 keys
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected        668.6, actual    661 (0.99x) (-7)
-Testing collisions (high 24-37 bits) - Worst is 28 bits: 10767/10667 (1.01x)
-Testing collisions (low  32-bit) - Expected        668.6, actual    756 (1.13x) (88)
-Testing collisions (low  24-37 bits) - Worst is 35 bits: 99/83 (1.18x)
-Testing distribution - Worst bias is the 18-bit window at bit 41 - 0.081%
+Testing collisions (high 32-bit) - Expected        668.6, actual    693 (1.04x) (25)
+Testing collisions (high 24-37 bits) - Worst is 32 bits: 693/668 (1.04x)
+Testing collisions (low  32-bit) - Expected        668.6, actual    634 (0.95x)
+Testing collisions (low  24-37 bits) - Worst is 37 bits: 26/20 (1.24x)
+Testing distribution - Worst bias is the 18-bit window at bit 22 - 0.093%
 
 
 Combination Highbits Tests
 Keyset 'Combination' - up to 7 blocks from a set of 8 - 2396744 keys
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
 Testing collisions (high 32-bit) - Expected        668.6, actual    672 (1.01x) (4)
-Testing collisions (high 24-37 bits) - Worst is 31 bits: 1379/1336 (1.03x)
-Testing collisions (low  32-bit) - Expected        668.6, actual    680 (1.02x) (12)
-Testing collisions (low  24-37 bits) - Worst is 31 bits: 1387/1336 (1.04x)
-Testing distribution - Worst bias is the 18-bit window at bit 26 - 0.054%
+Testing collisions (high 24-37 bits) - Worst is 36 bits: 47/41 (1.12x)
+Testing collisions (low  32-bit) - Expected        668.6, actual    644 (0.96x)
+Testing collisions (low  24-37 bits) - Worst is 28 bits: 10798/10667 (1.01x)
+Testing distribution - Worst bias is the 18-bit window at bit 32 - 0.067%
 
 
 Combination Hi-Lo Tests:
 Keyset 'Combination' - up to 6 blocks from a set of 15 - 12204240 keys
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected      17322.9, actual  17435 (1.01x) (113)
+Testing collisions (high 32-bit) - Expected      17322.9, actual  17436 (1.01x) (114)
 Testing collisions (high 27-41 bits) - Worst is 41 bits: 39/33 (1.15x)
-Testing collisions (low  32-bit) - Expected      17322.9, actual  17089 (0.99x) (-233)
-Testing collisions (low  27-41 bits) - Worst is 40 bits: 79/67 (1.17x)
-Testing distribution - Worst bias is the 20-bit window at bit 15 - 0.026%
+Testing collisions (low  32-bit) - Expected      17322.9, actual  17236 (0.99x) (-86)
+Testing collisions (low  27-41 bits) - Worst is 41 bits: 36/33 (1.06x)
+Testing distribution - Worst bias is the 20-bit window at bit 26 - 0.022%
 
 
 Combination 0x8000000 Tests:
 Keyset 'Combination' - up to 22 blocks from a set of 2 - 8388606 keys
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected       8186.7, actual   8218 (1.00x) (32)
-Testing collisions (high 26-40 bits) - Worst is 40 bits: 40/31 (1.25x)
-Testing collisions (low  32-bit) - Expected       8186.7, actual   8210 (1.00x) (24)
-Testing collisions (low  26-40 bits) - Worst is 32 bits: 8210/8186 (1.00x)
-Testing distribution - Worst bias is the 20-bit window at bit 16 - 0.047%
+Testing collisions (high 32-bit) - Expected       8186.7, actual   8158 (1.00x) (-28)
+Testing collisions (high 26-40 bits) - Worst is 38 bits: 133/127 (1.04x)
+Testing collisions (low  32-bit) - Expected       8186.7, actual   8229 (1.01x) (43)
+Testing collisions (low  26-40 bits) - Worst is 35 bits: 1050/1023 (1.03x)
+Testing distribution - Worst bias is the 20-bit window at bit 13 - 0.048%
 
 
 Combination 0x0000001 Tests:
 Keyset 'Combination' - up to 22 blocks from a set of 2 - 8388606 keys
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected       8186.7, actual   8118 (0.99x) (-68)
-Testing collisions (high 26-40 bits) - Worst is 26 bits: 503735/503108 (1.00x)
-Testing collisions (low  32-bit) - Expected       8186.7, actual   8308 (1.01x) (122)
-Testing collisions (low  26-40 bits) - Worst is 37 bits: 272/255 (1.06x)
-Testing distribution - Worst bias is the 20-bit window at bit 59 - 0.056%
+Testing collisions (high 32-bit) - Expected       8186.7, actual   8178 (1.00x) (-8)
+Testing collisions (high 26-40 bits) - Worst is 31 bits: 16405/16362 (1.00x)
+Testing collisions (low  32-bit) - Expected       8186.7, actual   8238 (1.01x) (52)
+Testing collisions (low  26-40 bits) - Worst is 40 bits: 36/31 (1.13x)
+Testing distribution - Worst bias is the 20-bit window at bit 48 - 0.036%
 
 
 Combination 0x800000000000000 Tests:
 Keyset 'Combination' - up to 22 blocks from a set of 2 - 8388606 keys
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected       8186.7, actual   8204 (1.00x) (18)
-Testing collisions (high 26-40 bits) - Worst is 39 bits: 70/63 (1.09x)
-Testing collisions (low  32-bit) - Expected       8186.7, actual   8149 (1.00x) (-37)
-Testing collisions (low  26-40 bits) - Worst is 30 bits: 32824/32682 (1.00x)
-Testing distribution - Worst bias is the 20-bit window at bit 61 - 0.039%
+Testing collisions (high 32-bit) - Expected       8186.7, actual   8237 (1.01x) (51)
+Testing collisions (high 26-40 bits) - Worst is 40 bits: 40/31 (1.25x)
+Testing collisions (low  32-bit) - Expected       8186.7, actual   8221 (1.00x) (35)
+Testing collisions (low  26-40 bits) - Worst is 40 bits: 42/31 (1.31x)
+Testing distribution - Worst bias is the 20-bit window at bit 15 - 0.045%
 
 
 Combination 0x000000000000001 Tests:
 Keyset 'Combination' - up to 22 blocks from a set of 2 - 8388606 keys
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected       8186.7, actual   8288 (1.01x) (102)
-Testing collisions (high 26-40 bits) - Worst is 31 bits: 16594/16362 (1.01x)
-Testing collisions (low  32-bit) - Expected       8186.7, actual   8159 (1.00x) (-27)
-Testing collisions (low  26-40 bits) - Worst is 34 bits: 2078/2047 (1.01x)
-Testing distribution - Worst bias is the 20-bit window at bit 33 - 0.030%
+Testing collisions (high 32-bit) - Expected       8186.7, actual   8213 (1.00x) (27)
+Testing collisions (high 26-40 bits) - Worst is 39 bits: 75/63 (1.17x)
+Testing collisions (low  32-bit) - Expected       8186.7, actual   8324 (1.02x) (138)
+Testing collisions (low  26-40 bits) - Worst is 39 bits: 76/63 (1.19x)
+Testing distribution - Worst bias is the 20-bit window at bit 30 - 0.042%
 
 
 Combination 16-bytes [0-1] Tests:
 Keyset 'Combination' - up to 22 blocks from a set of 2 - 8388606 keys
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected       8186.7, actual   8107 (0.99x) (-79)
-Testing collisions (high 26-40 bits) - Worst is 38 bits: 134/127 (1.05x)
-Testing collisions (low  32-bit) - Expected       8186.7, actual   8153 (1.00x) (-33)
-Testing collisions (low  26-40 bits) - Worst is 39 bits: 70/63 (1.09x)
-Testing distribution - Worst bias is the 20-bit window at bit 10 - 0.046%
+Testing collisions (high 32-bit) - Expected       8186.7, actual   8277 (1.01x) (91)
+Testing collisions (high 26-40 bits) - Worst is 40 bits: 38/31 (1.19x)
+Testing collisions (low  32-bit) - Expected       8186.7, actual   8219 (1.00x) (33)
+Testing collisions (low  26-40 bits) - Worst is 32 bits: 8219/8186 (1.00x)
+Testing distribution - Worst bias is the 20-bit window at bit 60 - 0.037%
 
 
 Combination 16-bytes [0-last] Tests:
 Keyset 'Combination' - up to 22 blocks from a set of 2 - 8388606 keys
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected       8186.7, actual   8163 (1.00x) (-23)
-Testing collisions (high 26-40 bits) - Worst is 38 bits: 144/127 (1.13x)
-Testing collisions (low  32-bit) - Expected       8186.7, actual   8116 (0.99x) (-70)
-Testing collisions (low  26-40 bits) - Worst is 26 bits: 504097/503108 (1.00x)
-Testing distribution - Worst bias is the 20-bit window at bit 16 - 0.042%
+Testing collisions (high 32-bit) - Expected       8186.7, actual   8215 (1.00x) (29)
+Testing collisions (high 26-40 bits) - Worst is 33 bits: 4122/4094 (1.01x)
+Testing collisions (low  32-bit) - Expected       8186.7, actual   8281 (1.01x) (95)
+Testing collisions (low  26-40 bits) - Worst is 32 bits: 8281/8186 (1.01x)
+Testing distribution - Worst bias is the 20-bit window at bit 28 - 0.051%
 
 
 Combination 32-bytes [0-1] Tests:
 Keyset 'Combination' - up to 22 blocks from a set of 2 - 8388606 keys
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected       8186.7, actual   8390 (1.02x) (204)
-Testing collisions (high 26-40 bits) - Worst is 40 bits: 34/31 (1.06x)
-Testing collisions (low  32-bit) - Expected       8186.7, actual   8106 (0.99x) (-80)
-Testing collisions (low  26-40 bits) - Worst is 26 bits: 502218/503108 (1.00x)
-Testing distribution - Worst bias is the 20-bit window at bit  6 - 0.037%
+Testing collisions (high 32-bit) - Expected       8186.7, actual   8101 (0.99x) (-85)
+Testing collisions (high 26-40 bits) - Worst is 26 bits: 503871/503108 (1.00x)
+Testing collisions (low  32-bit) - Expected       8186.7, actual   8230 (1.01x) (44)
+Testing collisions (low  26-40 bits) - Worst is 38 bits: 143/127 (1.12x)
+Testing distribution - Worst bias is the 20-bit window at bit 34 - 0.035%
 
 
 Combination 32-bytes [0-last] Tests:
 Keyset 'Combination' - up to 22 blocks from a set of 2 - 8388606 keys
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected       8186.7, actual   8387 (1.02x) (201)
-Testing collisions (high 26-40 bits) - Worst is 38 bits: 144/127 (1.13x)
-Testing collisions (low  32-bit) - Expected       8186.7, actual   7860 (0.96x)
-Testing collisions (low  26-40 bits) - Worst is 26 bits: 503416/503108 (1.00x)
-Testing distribution - Worst bias is the 20-bit window at bit 22 - 0.030%
+Testing collisions (high 32-bit) - Expected       8186.7, actual   8055 (0.98x) (-131)
+Testing collisions (high 26-40 bits) - Worst is 37 bits: 261/255 (1.02x)
+Testing collisions (low  32-bit) - Expected       8186.7, actual   8018 (0.98x)
+Testing collisions (low  26-40 bits) - Worst is 40 bits: 43/31 (1.34x)
+Testing distribution - Worst bias is the 20-bit window at bit 20 - 0.042%
 
 
 Combination 64-bytes [0-1] Tests:
 Keyset 'Combination' - up to 22 blocks from a set of 2 - 8388606 keys
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected       8186.7, actual   8126 (0.99x) (-60)
-Testing collisions (high 26-40 bits) - Worst is 38 bits: 148/127 (1.16x)
-Testing collisions (low  32-bit) - Expected       8186.7, actual   8171 (1.00x) (-15)
-Testing collisions (low  26-40 bits) - Worst is 36 bits: 523/511 (1.02x)
-Testing distribution - Worst bias is the 20-bit window at bit 40 - 0.042%
+Testing collisions (high 32-bit) - Expected       8186.7, actual   8397 (1.03x) (211)
+Testing collisions (high 26-40 bits) - Worst is 33 bits: 4244/4094 (1.04x)
+Testing collisions (low  32-bit) - Expected       8186.7, actual   8234 (1.01x) (48)
+Testing collisions (low  26-40 bits) - Worst is 39 bits: 69/63 (1.08x)
+Testing distribution - Worst bias is the 20-bit window at bit 42 - 0.041%
 
 
 Combination 64-bytes [0-last] Tests:
 Keyset 'Combination' - up to 22 blocks from a set of 2 - 8388606 keys
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected       8186.7, actual   8289 (1.01x) (103)
-Testing collisions (high 26-40 bits) - Worst is 36 bits: 546/511 (1.07x)
-Testing collisions (low  32-bit) - Expected       8186.7, actual   8002 (0.98x)
-Testing collisions (low  26-40 bits) - Worst is 39 bits: 66/63 (1.03x)
-Testing distribution - Worst bias is the 20-bit window at bit  7 - 0.039%
+Testing collisions (high 32-bit) - Expected       8186.7, actual   8164 (1.00x) (-22)
+Testing collisions (high 26-40 bits) - Worst is 39 bits: 70/63 (1.09x)
+Testing collisions (low  32-bit) - Expected       8186.7, actual   8084 (0.99x) (-102)
+Testing collisions (low  26-40 bits) - Worst is 40 bits: 33/31 (1.03x)
+Testing distribution - Worst bias is the 20-bit window at bit 41 - 0.049%
 
 
 Combination 128-bytes [0-1] Tests:
 Keyset 'Combination' - up to 22 blocks from a set of 2 - 8388606 keys
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected       8186.7, actual   8099 (0.99x) (-87)
-Testing collisions (high 26-40 bits) - Worst is 40 bits: 38/31 (1.19x)
-Testing collisions (low  32-bit) - Expected       8186.7, actual   8269 (1.01x) (83)
-Testing collisions (low  26-40 bits) - Worst is 40 bits: 40/31 (1.25x)
-Testing distribution - Worst bias is the 20-bit window at bit 10 - 0.029%
+Testing collisions (high 32-bit) - Expected       8186.7, actual   8193 (1.00x) (7)
+Testing collisions (high 26-40 bits) - Worst is 34 bits: 2090/2047 (1.02x)
+Testing collisions (low  32-bit) - Expected       8186.7, actual   8006 (0.98x)
+Testing collisions (low  26-40 bits) - Worst is 38 bits: 151/127 (1.18x)
+Testing distribution - Worst bias is the 20-bit window at bit 58 - 0.032%
 
 
 Combination 128-bytes [0-last] Tests:
 Keyset 'Combination' - up to 22 blocks from a set of 2 - 8388606 keys
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected       8186.7, actual   8279 (1.01x) (93)
-Testing collisions (high 26-40 bits) - Worst is 40 bits: 39/31 (1.22x)
-Testing collisions (low  32-bit) - Expected       8186.7, actual   8252 (1.01x) (66)
-Testing collisions (low  26-40 bits) - Worst is 39 bits: 75/63 (1.17x)
-Testing distribution - Worst bias is the 20-bit window at bit  9 - 0.029%
+Testing collisions (high 32-bit) - Expected       8186.7, actual   8109 (0.99x) (-77)
+Testing collisions (high 26-40 bits) - Worst is 38 bits: 137/127 (1.07x)
+Testing collisions (low  32-bit) - Expected       8186.7, actual   8095 (0.99x) (-91)
+Testing collisions (low  26-40 bits) - Worst is 34 bits: 2059/2047 (1.01x)
+Testing distribution - Worst bias is the 20-bit window at bit 51 - 0.040%
 
 
 [[[ Keyset 'Window' Tests ]]]
@@ -388,184 +388,184 @@ Window at  32 - Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0
 
 Keyset 'Cyclic' - 8 cycles of 8 bytes - 1000000 keys
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected        116.4, actual    103 (0.88x)
-Testing collisions (high 23-34 bits) - Worst is 30 bits: 495/465 (1.06x)
-Testing collisions (low  32-bit) - Expected        116.4, actual    109 (0.94x)
+Testing collisions (high 32-bit) - Expected        116.4, actual    116 (1.00x)
+Testing collisions (high 23-34 bits) - Worst is 34 bits: 32/29 (1.10x)
+Testing collisions (low  32-bit) - Expected        116.4, actual    114 (0.98x)
 Testing collisions (low  23-34 bits) - Worst is 30 bits: 468/465 (1.01x)
-Testing distribution - Worst bias is the 17-bit window at bit 37 - 0.111%
+Testing distribution - Worst bias is the 17-bit window at bit  8 - 0.118%
 
 Keyset 'Cyclic' - 8 cycles of 9 bytes - 1000000 keys
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected        116.4, actual    106 (0.91x)
-Testing collisions (high 23-34 bits) - Worst is 33 bits: 62/58 (1.07x)
-Testing collisions (low  32-bit) - Expected        116.4, actual    120 (1.03x) (4)
-Testing collisions (low  23-34 bits) - Worst is 34 bits: 46/29 (1.58x)
-Testing distribution - Worst bias is the 17-bit window at bit 48 - 0.132%
+Testing collisions (high 32-bit) - Expected        116.4, actual    104 (0.89x)
+Testing collisions (high 23-34 bits) - Worst is 24 bits: 29435/29218 (1.01x)
+Testing collisions (low  32-bit) - Expected        116.4, actual    116 (1.00x)
+Testing collisions (low  23-34 bits) - Worst is 34 bits: 39/29 (1.34x)
+Testing distribution - Worst bias is the 17-bit window at bit 26 - 0.084%
 
 Keyset 'Cyclic' - 8 cycles of 10 bytes - 1000000 keys
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected        116.4, actual    116 (1.00x)
-Testing collisions (high 23-34 bits) - Worst is 33 bits: 63/58 (1.08x)
-Testing collisions (low  32-bit) - Expected        116.4, actual    116 (1.00x)
-Testing collisions (low  23-34 bits) - Worst is 33 bits: 68/58 (1.17x)
-Testing distribution - Worst bias is the 17-bit window at bit 60 - 0.103%
+Testing collisions (high 32-bit) - Expected        116.4, actual    126 (1.08x) (10)
+Testing collisions (high 23-34 bits) - Worst is 31 bits: 257/232 (1.10x)
+Testing collisions (low  32-bit) - Expected        116.4, actual    122 (1.05x) (6)
+Testing collisions (low  23-34 bits) - Worst is 33 bits: 67/58 (1.15x)
+Testing distribution - Worst bias is the 17-bit window at bit 16 - 0.128%
 
 Keyset 'Cyclic' - 8 cycles of 11 bytes - 1000000 keys
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected        116.4, actual    129 (1.11x) (13)
-Testing collisions (high 23-34 bits) - Worst is 33 bits: 69/58 (1.19x)
-Testing collisions (low  32-bit) - Expected        116.4, actual    120 (1.03x) (4)
-Testing collisions (low  23-34 bits) - Worst is 32 bits: 120/116 (1.03x)
-Testing distribution - Worst bias is the 17-bit window at bit 27 - 0.109%
+Testing collisions (high 32-bit) - Expected        116.4, actual    144 (1.24x) (28)
+Testing collisions (high 23-34 bits) - Worst is 32 bits: 144/116 (1.24x)
+Testing collisions (low  32-bit) - Expected        116.4, actual    114 (0.98x)
+Testing collisions (low  23-34 bits) - Worst is 34 bits: 34/29 (1.17x)
+Testing distribution - Worst bias is the 17-bit window at bit 16 - 0.097%
 
 Keyset 'Cyclic' - 8 cycles of 12 bytes - 1000000 keys
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected        116.4, actual     95 (0.82x)
-Testing collisions (high 23-34 bits) - Worst is 23 bits: 56886/57305 (0.99x)
-Testing collisions (low  32-bit) - Expected        116.4, actual    120 (1.03x) (4)
-Testing collisions (low  23-34 bits) - Worst is 34 bits: 34/29 (1.17x)
-Testing distribution - Worst bias is the 17-bit window at bit 46 - 0.134%
+Testing collisions (high 32-bit) - Expected        116.4, actual    110 (0.94x)
+Testing collisions (high 23-34 bits) - Worst is 34 bits: 35/29 (1.20x)
+Testing collisions (low  32-bit) - Expected        116.4, actual    109 (0.94x)
+Testing collisions (low  23-34 bits) - Worst is 25 bits: 14795/14754 (1.00x)
+Testing distribution - Worst bias is the 17-bit window at bit 36 - 0.084%
 
 Keyset 'Cyclic' - 8 cycles of 16 bytes - 1000000 keys
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected        116.4, actual    126 (1.08x) (10)
-Testing collisions (high 23-34 bits) - Worst is 33 bits: 79/58 (1.36x)
-Testing collisions (low  32-bit) - Expected        116.4, actual     98 (0.84x)
-Testing collisions (low  23-34 bits) - Worst is 23 bits: 57131/57305 (1.00x)
-Testing distribution - Worst bias is the 17-bit window at bit 31 - 0.147%
+Testing collisions (high 32-bit) - Expected        116.4, actual    116 (1.00x)
+Testing collisions (high 23-34 bits) - Worst is 31 bits: 240/232 (1.03x)
+Testing collisions (low  32-bit) - Expected        116.4, actual    114 (0.98x)
+Testing collisions (low  23-34 bits) - Worst is 31 bits: 259/232 (1.11x)
+Testing distribution - Worst bias is the 17-bit window at bit 47 - 0.123%
 
 
 [[[ Keyset 'TwoBytes' Tests ]]]
 
 Keyset 'TwoBytes' - up-to-4-byte keys, 652545 total keys
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected         49.6, actual     42 (0.85x)
-Testing collisions (high 23-33 bits) - Worst is 24 bits: 12603/12527 (1.01x)
-Testing collisions (low  32-bit) - Expected         49.6, actual     44 (0.89x)
-Testing collisions (low  23-33 bits) - Worst is 27 bits: 1606/1583 (1.01x)
-Testing distribution - Worst bias is the 16-bit window at bit 36 - 0.093%
+Testing collisions (high 32-bit) - Expected         49.6, actual     52 (1.05x) (3)
+Testing collisions (high 23-33 bits) - Worst is 33 bits: 29/24 (1.17x)
+Testing collisions (low  32-bit) - Expected         49.6, actual     42 (0.85x)
+Testing collisions (low  23-33 bits) - Worst is 33 bits: 27/24 (1.09x)
+Testing distribution - Worst bias is the 16-bit window at bit 52 - 0.122%
 
 Keyset 'TwoBytes' - up-to-8-byte keys, 5471025 total keys
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected       3483.1, actual   3401 (0.98x)
-Testing collisions (high 26-39 bits) - Worst is 37 bits: 111/108 (1.02x)
-Testing collisions (low  32-bit) - Expected       3483.1, actual   3448 (0.99x) (-35)
-Testing collisions (low  26-39 bits) - Worst is 37 bits: 121/108 (1.11x)
-Testing distribution - Worst bias is the 20-bit window at bit 57 - 0.040%
+Testing collisions (high 32-bit) - Expected       3483.1, actual   3394 (0.97x)
+Testing collisions (high 26-39 bits) - Worst is 39 bits: 30/27 (1.10x)
+Testing collisions (low  32-bit) - Expected       3483.1, actual   3467 (1.00x) (-16)
+Testing collisions (low  26-39 bits) - Worst is 36 bits: 231/217 (1.06x)
+Testing distribution - Worst bias is the 20-bit window at bit 59 - 0.057%
 
 Keyset 'TwoBytes' - up-to-12-byte keys, 18616785 total keys
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected      40289.5, actual  39941 (0.99x) (-348)
-Testing collisions (high 27-42 bits) - Worst is 27 bits: 1233062/1233446 (1.00x)
-Testing collisions (low  32-bit) - Expected      40289.5, actual  40360 (1.00x) (71)
-Testing collisions (low  27-42 bits) - Worst is 37 bits: 1310/1260 (1.04x)
-Testing distribution - Worst bias is the 20-bit window at bit 62 - 0.019%
+Testing collisions (high 32-bit) - Expected      40289.5, actual  40020 (0.99x) (-269)
+Testing collisions (high 27-42 bits) - Worst is 38 bits: 666/630 (1.06x)
+Testing collisions (low  32-bit) - Expected      40289.5, actual  40431 (1.00x) (142)
+Testing collisions (low  27-42 bits) - Worst is 29 bits: 320229/319083 (1.00x)
+Testing distribution - Worst bias is the 20-bit window at bit 13 - 0.017%
 
 Keyset 'TwoBytes' - up-to-16-byte keys, 44251425 total keys
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected     227182.3, actual 227244 (1.00x) (62)
-Testing collisions (high 29-45 bits) - Worst is 44 bits: 60/55 (1.08x)
-Testing collisions (low  32-bit) - Expected     227182.3, actual 227447 (1.00x) (265)
-Testing collisions (low  29-45 bits) - Worst is 37 bits: 7356/7123 (1.03x)
-Testing distribution - Worst bias is the 19-bit window at bit  1 - 0.004%
+Testing collisions (high 32-bit) - Expected     227182.3, actual 227270 (1.00x) (88)
+Testing collisions (high 29-45 bits) - Worst is 44 bits: 67/55 (1.20x)
+Testing collisions (low  32-bit) - Expected     227182.3, actual 227273 (1.00x) (91)
+Testing collisions (low  29-45 bits) - Worst is 39 bits: 1795/1780 (1.01x)
+Testing distribution - Worst bias is the 20-bit window at bit 42 - 0.009%
 
 Keyset 'TwoBytes' - up-to-20-byte keys, 86536545 total keys
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected     865959.1, actual 866640 (1.00x) (681)
-Testing collisions (high 30-47 bits) - Worst is 44 bits: 230/212 (1.08x)
-Testing collisions (low  32-bit) - Expected     865959.1, actual 866255 (1.00x) (296)
-Testing collisions (low  30-47 bits) - Worst is 38 bits: 13774/13620 (1.01x)
-Testing distribution - Worst bias is the 20-bit window at bit 50 - 0.005%
+Testing collisions (high 32-bit) - Expected     865959.1, actual 866294 (1.00x) (335)
+Testing collisions (high 30-47 bits) - Worst is 45 bits: 123/106 (1.16x)
+Testing collisions (low  32-bit) - Expected     865959.1, actual 864993 (1.00x) (-966)
+Testing collisions (low  30-47 bits) - Worst is 47 bits: 30/26 (1.13x)
+Testing distribution - Worst bias is the 20-bit window at bit 53 - 0.003%
 
 
 [[[ Keyset 'Text' Tests ]]]
 
 Keyset 'Text' - keys of form "FooXXXXBar" - 14776336 keys
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected      25389.0, actual  25650 (1.01x) (261)
-Testing collisions (high 27-42 bits) - Worst is 39 bits: 208/198 (1.05x)
-Testing collisions (low  32-bit) - Expected      25389.0, actual  25416 (1.00x) (27)
-Testing collisions (low  27-42 bits) - Worst is 36 bits: 1653/1588 (1.04x)
-Testing distribution - Worst bias is the 20-bit window at bit  7 - 0.019%
+Testing collisions (high 32-bit) - Expected      25389.0, actual  25536 (1.01x) (147)
+Testing collisions (high 27-42 bits) - Worst is 42 bits: 31/24 (1.25x)
+Testing collisions (low  32-bit) - Expected      25389.0, actual  25106 (0.99x) (-283)
+Testing collisions (low  27-42 bits) - Worst is 40 bits: 107/99 (1.08x)
+Testing distribution - Worst bias is the 20-bit window at bit  4 - 0.021%
 
 Keyset 'Text' - keys of form "FooBarXXXX" - 14776336 keys
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected      25389.0, actual  25488 (1.00x) (99)
-Testing collisions (high 27-42 bits) - Worst is 40 bits: 106/99 (1.07x)
-Testing collisions (low  32-bit) - Expected      25389.0, actual  25444 (1.00x) (55)
-Testing collisions (low  27-42 bits) - Worst is 42 bits: 27/24 (1.09x)
-Testing distribution - Worst bias is the 19-bit window at bit 58 - 0.011%
+Testing collisions (high 32-bit) - Expected      25389.0, actual  25442 (1.00x) (53)
+Testing collisions (high 27-42 bits) - Worst is 38 bits: 414/397 (1.04x)
+Testing collisions (low  32-bit) - Expected      25389.0, actual  25549 (1.01x) (160)
+Testing collisions (low  27-42 bits) - Worst is 42 bits: 26/24 (1.05x)
+Testing distribution - Worst bias is the 20-bit window at bit 49 - 0.037%
 
 Keyset 'Text' - keys of form "XXXXFooBar" - 14776336 keys
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected      25389.0, actual  25061 (0.99x) (-328)
-Testing collisions (high 27-42 bits) - Worst is 41 bits: 58/49 (1.17x)
-Testing collisions (low  32-bit) - Expected      25389.0, actual  25212 (0.99x) (-177)
-Testing collisions (low  27-42 bits) - Worst is 37 bits: 799/794 (1.01x)
-Testing distribution - Worst bias is the 20-bit window at bit  6 - 0.024%
+Testing collisions (high 32-bit) - Expected      25389.0, actual  25430 (1.00x) (41)
+Testing collisions (high 27-42 bits) - Worst is 40 bits: 121/99 (1.22x)
+Testing collisions (low  32-bit) - Expected      25389.0, actual  25196 (0.99x) (-193)
+Testing collisions (low  27-42 bits) - Worst is 42 bits: 32/24 (1.29x)
+Testing distribution - Worst bias is the 20-bit window at bit 49 - 0.017%
 
 Keyset 'Words' - 4000000 random keys of len 6-16 from alnum charset
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected       1862.1, actual   1864 (1.00x) (2)
+Testing collisions (high 32-bit) - Expected       1862.1, actual   1941 (1.04x) (79)
 Testing collisions (high 25-38 bits) - Worst is 38 bits: 41/29 (1.41x)
-Testing collisions (low  32-bit) - Expected       1862.1, actual   1930 (1.04x) (68)
-Testing collisions (low  25-38 bits) - Worst is 35 bits: 251/232 (1.08x)
-Testing distribution - Worst bias is the 19-bit window at bit 51 - 0.057%
+Testing collisions (low  32-bit) - Expected       1862.1, actual   1816 (0.98x)
+Testing collisions (low  25-38 bits) - Worst is 26 bits: 117041/116875 (1.00x)
+Testing distribution - Worst bias is the 19-bit window at bit 53 - 0.037%
 
 Keyset 'Words' - 4000000 random keys of len 6-16 from password charset
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected       1862.1, actual   1875 (1.01x) (13)
-Testing collisions (high 25-38 bits) - Worst is 33 bits: 954/931 (1.02x)
-Testing collisions (low  32-bit) - Expected       1862.1, actual   1891 (1.02x) (29)
-Testing collisions (low  25-38 bits) - Worst is 38 bits: 31/29 (1.07x)
-Testing distribution - Worst bias is the 19-bit window at bit 36 - 0.055%
+Testing collisions (high 32-bit) - Expected       1862.1, actual   1911 (1.03x) (49)
+Testing collisions (high 25-38 bits) - Worst is 38 bits: 31/29 (1.07x)
+Testing collisions (low  32-bit) - Expected       1862.1, actual   1872 (1.01x) (10)
+Testing collisions (low  25-38 bits) - Worst is 34 bits: 503/465 (1.08x)
+Testing distribution - Worst bias is the 18-bit window at bit 17 - 0.046%
 
 Keyset 'Words' - 104334 dict words
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected          1.3, actual      0 (0.00x)
-Testing collisions (high 20-28 bits) - Worst is 21 bits: 2566/2552 (1.01x)
+Testing collisions (high 32-bit) - Expected          1.3, actual      1 (0.79x)
+Testing collisions (high 20-28 bits) - Worst is 26 bits: 82/81 (1.01x)
 Testing collisions (low  32-bit) - Expected          1.3, actual      1 (0.79x)
-Testing collisions (low  20-28 bits) - Worst is 22 bits: 1301/1286 (1.01x)
-Testing distribution - Worst bias is the 14-bit window at bit 35 - 0.260%
+Testing collisions (low  20-28 bits) - Worst is 28 bits: 24/20 (1.18x)
+Testing distribution - Worst bias is the 14-bit window at bit 60 - 0.295%
 
 
 [[[ Keyset 'Zeroes' Tests ]]]
 
 Keyset 'Zeroes' - 204800 keys
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected          4.9, actual      8 (1.64x) (4)
-Testing collisions (high 21-29 bits) - Worst is 27 bits: 161/156 (1.03x)
-Testing collisions (low  32-bit) - Expected          4.9, actual      4 (0.82x)
-Testing collisions (low  21-29 bits) - Worst is 26 bits: 317/312 (1.02x)
-Testing distribution - Worst bias is the 15-bit window at bit 51 - 0.517%
+Testing collisions (high 32-bit) - Expected          4.9, actual      2 (0.41x)
+Testing collisions (high 21-29 bits) - Worst is 26 bits: 337/312 (1.08x)
+Testing collisions (low  32-bit) - Expected          4.9, actual      5 (1.02x) (1)
+Testing collisions (low  21-29 bits) - Worst is 29 bits: 44/39 (1.13x)
+Testing distribution - Worst bias is the 15-bit window at bit 53 - 0.229%
 
 
 [[[ Keyset 'Seed' Tests ]]]
 
 Keyset 'Seed' - 5000000 keys
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected       2909.3, actual   2977 (1.02x) (68)
-Testing collisions (high 26-39 bits) - Worst is 38 bits: 52/45 (1.14x)
-Testing collisions (low  32-bit) - Expected       2909.3, actual   2918 (1.00x) (9)
-Testing collisions (low  26-39 bits) - Worst is 37 bits: 100/90 (1.10x)
-Testing distribution - Worst bias is the 19-bit window at bit 54 - 0.037%
+Testing collisions (high 32-bit) - Expected       2909.3, actual   2940 (1.01x) (31)
+Testing collisions (high 26-39 bits) - Worst is 36 bits: 202/181 (1.11x)
+Testing collisions (low  32-bit) - Expected       2909.3, actual   2971 (1.02x) (62)
+Testing collisions (low  26-39 bits) - Worst is 39 bits: 26/22 (1.14x)
+Testing distribution - Worst bias is the 19-bit window at bit 31 - 0.037%
 
 
 [[[ Keyset 'PerlinNoise' Tests ]]]
 
 Testing 16777216 coordinates (L2) :
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected      32725.4, actual  32878 (1.00x) (153)
-Testing collisions (high 27-42 bits) - Worst is 34 bits: 8352/8189 (1.02x)
-Testing collisions (low  32-bit) - Expected      32725.4, actual  32870 (1.00x) (145)
-Testing collisions (low  27-42 bits) - Worst is 34 bits: 8327/8189 (1.02x)
+Testing collisions (high 32-bit) - Expected      32725.4, actual  32639 (1.00x) (-86)
+Testing collisions (high 27-42 bits) - Worst is 38 bits: 551/511 (1.08x)
+Testing collisions (low  32-bit) - Expected      32725.4, actual  32654 (1.00x) (-71)
+Testing collisions (low  27-42 bits) - Worst is 39 bits: 261/255 (1.02x)
 
 Testing AV variant, 128 count with 4 spacing, 4-12:
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected       1116.2, actual   1100 (0.99x) (-16)
-Testing collisions (high 25-37 bits) - Worst is 37 bits: 36/34 (1.03x)
-Testing collisions (low  32-bit) - Expected       1116.2, actual   1150 (1.03x) (34)
-Testing collisions (low  25-37 bits) - Worst is 33 bits: 584/558 (1.05x)
+Testing collisions (high 32-bit) - Expected       1116.2, actual   1143 (1.02x) (27)
+Testing collisions (high 25-37 bits) - Worst is 37 bits: 39/34 (1.12x)
+Testing collisions (low  32-bit) - Expected       1116.2, actual   1111 (1.00x) (-5)
+Testing collisions (low  25-37 bits) - Worst is 35 bits: 160/139 (1.15x)
 
 
 [[[ Diff 'Differential' Tests ]]]
@@ -587,515 +587,515 @@ Testing 2796416 up-to-3-bit differentials in 256-bit keys -> 64 bit hashes.
 
 Testing bit 0
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected        511.9, actual    525 (1.03x) (14)
-Testing collisions (high 24-36 bits) - Worst is 33 bits: 289/255 (1.13x)
-Testing collisions (low  32-bit) - Expected        511.9, actual    555 (1.08x) (44)
-Testing collisions (low  24-36 bits) - Worst is 34 bits: 141/127 (1.10x)
-Testing distribution - Worst bias is the 18-bit window at bit 45 - 0.075%
+Testing collisions (high 32-bit) - Expected        511.9, actual    517 (1.01x) (6)
+Testing collisions (high 24-36 bits) - Worst is 35 bits: 67/63 (1.05x)
+Testing collisions (low  32-bit) - Expected        511.9, actual    519 (1.01x) (8)
+Testing collisions (low  24-36 bits) - Worst is 33 bits: 268/255 (1.05x)
+Testing distribution - Worst bias is the 18-bit window at bit 41 - 0.066%
 
 Testing bit 1
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected        511.9, actual    514 (1.00x) (3)
-Testing collisions (high 24-36 bits) - Worst is 31 bits: 1045/1023 (1.02x)
-Testing collisions (low  32-bit) - Expected        511.9, actual    543 (1.06x) (32)
-Testing collisions (low  24-36 bits) - Worst is 36 bits: 41/31 (1.28x)
-Testing distribution - Worst bias is the 18-bit window at bit 33 - 0.083%
+Testing collisions (high 32-bit) - Expected        511.9, actual    464 (0.91x)
+Testing collisions (high 24-36 bits) - Worst is 35 bits: 66/63 (1.03x)
+Testing collisions (low  32-bit) - Expected        511.9, actual    507 (0.99x) (-4)
+Testing collisions (low  24-36 bits) - Worst is 35 bits: 64/63 (1.00x)
+Testing distribution - Worst bias is the 18-bit window at bit 27 - 0.090%
 
 Testing bit 2
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected        511.9, actual    493 (0.96x)
-Testing collisions (high 24-36 bits) - Worst is 26 bits: 32575/32429 (1.00x)
-Testing collisions (low  32-bit) - Expected        511.9, actual    519 (1.01x) (8)
-Testing collisions (low  24-36 bits) - Worst is 34 bits: 134/127 (1.05x)
-Testing distribution - Worst bias is the 18-bit window at bit 43 - 0.101%
+Testing collisions (high 32-bit) - Expected        511.9, actual    526 (1.03x) (15)
+Testing collisions (high 24-36 bits) - Worst is 31 bits: 1068/1023 (1.04x)
+Testing collisions (low  32-bit) - Expected        511.9, actual    556 (1.09x) (45)
+Testing collisions (low  24-36 bits) - Worst is 34 bits: 154/127 (1.20x)
+Testing distribution - Worst bias is the 18-bit window at bit 50 - 0.074%
 
 Testing bit 3
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected        511.9, actual    511 (1.00x)
-Testing collisions (high 24-36 bits) - Worst is 35 bits: 78/63 (1.22x)
-Testing collisions (low  32-bit) - Expected        511.9, actual    521 (1.02x) (10)
-Testing collisions (low  24-36 bits) - Worst is 35 bits: 77/63 (1.20x)
-Testing distribution - Worst bias is the 18-bit window at bit 31 - 0.067%
+Testing collisions (high 32-bit) - Expected        511.9, actual    534 (1.04x) (23)
+Testing collisions (high 24-36 bits) - Worst is 35 bits: 72/63 (1.13x)
+Testing collisions (low  32-bit) - Expected        511.9, actual    527 (1.03x) (16)
+Testing collisions (low  24-36 bits) - Worst is 34 bits: 140/127 (1.09x)
+Testing distribution - Worst bias is the 18-bit window at bit 10 - 0.045%
 
 Testing bit 4
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected        511.9, actual    483 (0.94x)
-Testing collisions (high 24-36 bits) - Worst is 36 bits: 36/31 (1.13x)
-Testing collisions (low  32-bit) - Expected        511.9, actual    492 (0.96x)
-Testing collisions (low  24-36 bits) - Worst is 25 bits: 64466/64191 (1.00x)
-Testing distribution - Worst bias is the 17-bit window at bit 36 - 0.052%
+Testing collisions (high 32-bit) - Expected        511.9, actual    539 (1.05x) (28)
+Testing collisions (high 24-36 bits) - Worst is 31 bits: 1091/1023 (1.07x)
+Testing collisions (low  32-bit) - Expected        511.9, actual    589 (1.15x) (78)
+Testing collisions (low  24-36 bits) - Worst is 32 bits: 589/511 (1.15x)
+Testing distribution - Worst bias is the 18-bit window at bit 15 - 0.072%
 
 Testing bit 5
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected        511.9, actual    519 (1.01x) (8)
-Testing collisions (high 24-36 bits) - Worst is 36 bits: 39/31 (1.22x)
-Testing collisions (low  32-bit) - Expected        511.9, actual    542 (1.06x) (31)
-Testing collisions (low  24-36 bits) - Worst is 35 bits: 77/63 (1.20x)
-Testing distribution - Worst bias is the 18-bit window at bit 38 - 0.055%
+Testing collisions (high 32-bit) - Expected        511.9, actual    532 (1.04x) (21)
+Testing collisions (high 24-36 bits) - Worst is 34 bits: 139/127 (1.09x)
+Testing collisions (low  32-bit) - Expected        511.9, actual    478 (0.93x)
+Testing collisions (low  24-36 bits) - Worst is 24 bits: 125492/125777 (1.00x)
+Testing distribution - Worst bias is the 18-bit window at bit 35 - 0.067%
 
 Testing bit 6
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected        511.9, actual    549 (1.07x) (38)
-Testing collisions (high 24-36 bits) - Worst is 31 bits: 1115/1023 (1.09x)
-Testing collisions (low  32-bit) - Expected        511.9, actual    547 (1.07x) (36)
-Testing collisions (low  24-36 bits) - Worst is 36 bits: 40/31 (1.25x)
-Testing distribution - Worst bias is the 18-bit window at bit  4 - 0.116%
+Testing collisions (high 32-bit) - Expected        511.9, actual    546 (1.07x) (35)
+Testing collisions (high 24-36 bits) - Worst is 36 bits: 37/31 (1.16x)
+Testing collisions (low  32-bit) - Expected        511.9, actual    540 (1.05x) (29)
+Testing collisions (low  24-36 bits) - Worst is 35 bits: 81/63 (1.27x)
+Testing distribution - Worst bias is the 18-bit window at bit 39 - 0.073%
 
 Testing bit 7
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected        511.9, actual    515 (1.01x) (4)
-Testing collisions (high 24-36 bits) - Worst is 36 bits: 33/31 (1.03x)
-Testing collisions (low  32-bit) - Expected        511.9, actual    483 (0.94x)
-Testing collisions (low  24-36 bits) - Worst is 24 bits: 125823/125777 (1.00x)
-Testing distribution - Worst bias is the 18-bit window at bit 62 - 0.067%
+Testing collisions (high 32-bit) - Expected        511.9, actual    539 (1.05x) (28)
+Testing collisions (high 24-36 bits) - Worst is 33 bits: 293/255 (1.14x)
+Testing collisions (low  32-bit) - Expected        511.9, actual    560 (1.09x) (49)
+Testing collisions (low  24-36 bits) - Worst is 36 bits: 41/31 (1.28x)
+Testing distribution - Worst bias is the 18-bit window at bit 38 - 0.051%
 
 Testing bit 8
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected        511.9, actual    514 (1.00x) (3)
-Testing collisions (high 24-36 bits) - Worst is 31 bits: 1051/1023 (1.03x)
-Testing collisions (low  32-bit) - Expected        511.9, actual    511 (1.00x)
-Testing collisions (low  24-36 bits) - Worst is 35 bits: 67/63 (1.05x)
-Testing distribution - Worst bias is the 18-bit window at bit 36 - 0.091%
+Testing collisions (high 32-bit) - Expected        511.9, actual    554 (1.08x) (43)
+Testing collisions (high 24-36 bits) - Worst is 31 bits: 1113/1023 (1.09x)
+Testing collisions (low  32-bit) - Expected        511.9, actual    553 (1.08x) (42)
+Testing collisions (low  24-36 bits) - Worst is 36 bits: 43/31 (1.34x)
+Testing distribution - Worst bias is the 18-bit window at bit  4 - 0.102%
 
 Testing bit 9
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected        511.9, actual    524 (1.02x) (13)
-Testing collisions (high 24-36 bits) - Worst is 33 bits: 264/255 (1.03x)
-Testing collisions (low  32-bit) - Expected        511.9, actual    514 (1.00x) (3)
-Testing collisions (low  24-36 bits) - Worst is 36 bits: 45/31 (1.41x)
-Testing distribution - Worst bias is the 18-bit window at bit 42 - 0.069%
+Testing collisions (high 32-bit) - Expected        511.9, actual    531 (1.04x) (20)
+Testing collisions (high 24-36 bits) - Worst is 35 bits: 74/63 (1.16x)
+Testing collisions (low  32-bit) - Expected        511.9, actual    532 (1.04x) (21)
+Testing collisions (low  24-36 bits) - Worst is 36 bits: 35/31 (1.09x)
+Testing distribution - Worst bias is the 17-bit window at bit 19 - 0.078%
 
 Testing bit 10
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected        511.9, actual    502 (0.98x) (-9)
-Testing collisions (high 24-36 bits) - Worst is 35 bits: 75/63 (1.17x)
-Testing collisions (low  32-bit) - Expected        511.9, actual    503 (0.98x) (-8)
-Testing collisions (low  24-36 bits) - Worst is 30 bits: 2102/2046 (1.03x)
-Testing distribution - Worst bias is the 17-bit window at bit 43 - 0.085%
+Testing collisions (high 32-bit) - Expected        511.9, actual    547 (1.07x) (36)
+Testing collisions (high 24-36 bits) - Worst is 36 bits: 41/31 (1.28x)
+Testing collisions (low  32-bit) - Expected        511.9, actual    517 (1.01x) (6)
+Testing collisions (low  24-36 bits) - Worst is 32 bits: 517/511 (1.01x)
+Testing distribution - Worst bias is the 18-bit window at bit 39 - 0.067%
 
 Testing bit 11
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected        511.9, actual    480 (0.94x)
-Testing collisions (high 24-36 bits) - Worst is 30 bits: 2073/2046 (1.01x)
-Testing collisions (low  32-bit) - Expected        511.9, actual    527 (1.03x) (16)
-Testing collisions (low  24-36 bits) - Worst is 32 bits: 527/511 (1.03x)
-Testing distribution - Worst bias is the 18-bit window at bit 60 - 0.112%
+Testing collisions (high 32-bit) - Expected        511.9, actual    539 (1.05x) (28)
+Testing collisions (high 24-36 bits) - Worst is 33 bits: 273/255 (1.07x)
+Testing collisions (low  32-bit) - Expected        511.9, actual    532 (1.04x) (21)
+Testing collisions (low  24-36 bits) - Worst is 34 bits: 150/127 (1.17x)
+Testing distribution - Worst bias is the 18-bit window at bit  8 - 0.067%
 
 Testing bit 12
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected        511.9, actual    513 (1.00x) (2)
-Testing collisions (high 24-36 bits) - Worst is 35 bits: 71/63 (1.11x)
-Testing collisions (low  32-bit) - Expected        511.9, actual    524 (1.02x) (13)
-Testing collisions (low  24-36 bits) - Worst is 33 bits: 265/255 (1.04x)
-Testing distribution - Worst bias is the 18-bit window at bit 35 - 0.068%
+Testing collisions (high 32-bit) - Expected        511.9, actual    548 (1.07x) (37)
+Testing collisions (high 24-36 bits) - Worst is 35 bits: 69/63 (1.08x)
+Testing collisions (low  32-bit) - Expected        511.9, actual    537 (1.05x) (26)
+Testing collisions (low  24-36 bits) - Worst is 32 bits: 537/511 (1.05x)
+Testing distribution - Worst bias is the 18-bit window at bit  3 - 0.062%
 
 Testing bit 13
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected        511.9, actual    559 (1.09x) (48)
-Testing collisions (high 24-36 bits) - Worst is 35 bits: 73/63 (1.14x)
-Testing collisions (low  32-bit) - Expected        511.9, actual    555 (1.08x) (44)
-Testing collisions (low  24-36 bits) - Worst is 34 bits: 150/127 (1.17x)
-Testing distribution - Worst bias is the 18-bit window at bit 26 - 0.103%
+Testing collisions (high 32-bit) - Expected        511.9, actual    513 (1.00x) (2)
+Testing collisions (high 24-36 bits) - Worst is 36 bits: 37/31 (1.16x)
+Testing collisions (low  32-bit) - Expected        511.9, actual    532 (1.04x) (21)
+Testing collisions (low  24-36 bits) - Worst is 35 bits: 71/63 (1.11x)
+Testing distribution - Worst bias is the 18-bit window at bit 20 - 0.058%
 
 Testing bit 14
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected        511.9, actual    512 (1.00x) (1)
-Testing collisions (high 24-36 bits) - Worst is 34 bits: 134/127 (1.05x)
-Testing collisions (low  32-bit) - Expected        511.9, actual    506 (0.99x) (-5)
-Testing collisions (low  24-36 bits) - Worst is 35 bits: 69/63 (1.08x)
-Testing distribution - Worst bias is the 18-bit window at bit 28 - 0.064%
+Testing collisions (high 32-bit) - Expected        511.9, actual    486 (0.95x)
+Testing collisions (high 24-36 bits) - Worst is 28 bits: 8219/8170 (1.01x)
+Testing collisions (low  32-bit) - Expected        511.9, actual    494 (0.97x)
+Testing collisions (low  24-36 bits) - Worst is 30 bits: 2084/2046 (1.02x)
+Testing distribution - Worst bias is the 18-bit window at bit 33 - 0.095%
 
 Testing bit 15
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected        511.9, actual    526 (1.03x) (15)
-Testing collisions (high 24-36 bits) - Worst is 32 bits: 526/511 (1.03x)
-Testing collisions (low  32-bit) - Expected        511.9, actual    532 (1.04x) (21)
-Testing collisions (low  24-36 bits) - Worst is 31 bits: 1067/1023 (1.04x)
-Testing distribution - Worst bias is the 18-bit window at bit 18 - 0.076%
+Testing collisions (high 32-bit) - Expected        511.9, actual    471 (0.92x)
+Testing collisions (high 24-36 bits) - Worst is 35 bits: 72/63 (1.13x)
+Testing collisions (low  32-bit) - Expected        511.9, actual    493 (0.96x)
+Testing collisions (low  24-36 bits) - Worst is 27 bits: 16461/16298 (1.01x)
+Testing distribution - Worst bias is the 18-bit window at bit 60 - 0.069%
 
 Testing bit 16
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected        511.9, actual    542 (1.06x) (31)
-Testing collisions (high 24-36 bits) - Worst is 33 bits: 291/255 (1.14x)
-Testing collisions (low  32-bit) - Expected        511.9, actual    481 (0.94x)
-Testing collisions (low  24-36 bits) - Worst is 36 bits: 36/31 (1.13x)
-Testing distribution - Worst bias is the 18-bit window at bit 49 - 0.077%
+Testing collisions (high 32-bit) - Expected        511.9, actual    495 (0.97x)
+Testing collisions (high 24-36 bits) - Worst is 26 bits: 32491/32429 (1.00x)
+Testing collisions (low  32-bit) - Expected        511.9, actual    480 (0.94x)
+Testing collisions (low  24-36 bits) - Worst is 36 bits: 34/31 (1.06x)
+Testing distribution - Worst bias is the 18-bit window at bit 45 - 0.089%
 
 Testing bit 17
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected        511.9, actual    527 (1.03x) (16)
-Testing collisions (high 24-36 bits) - Worst is 36 bits: 37/31 (1.16x)
-Testing collisions (low  32-bit) - Expected        511.9, actual    546 (1.07x) (35)
-Testing collisions (low  24-36 bits) - Worst is 35 bits: 75/63 (1.17x)
-Testing distribution - Worst bias is the 18-bit window at bit 56 - 0.079%
+Testing collisions (high 32-bit) - Expected        511.9, actual    542 (1.06x) (31)
+Testing collisions (high 24-36 bits) - Worst is 36 bits: 39/31 (1.22x)
+Testing collisions (low  32-bit) - Expected        511.9, actual    515 (1.01x) (4)
+Testing collisions (low  24-36 bits) - Worst is 36 bits: 41/31 (1.28x)
+Testing distribution - Worst bias is the 18-bit window at bit 30 - 0.065%
 
 Testing bit 18
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected        511.9, actual    502 (0.98x) (-9)
-Testing collisions (high 24-36 bits) - Worst is 36 bits: 35/31 (1.09x)
-Testing collisions (low  32-bit) - Expected        511.9, actual    498 (0.97x)
-Testing collisions (low  24-36 bits) - Worst is 34 bits: 130/127 (1.02x)
-Testing distribution - Worst bias is the 18-bit window at bit 16 - 0.066%
+Testing collisions (high 32-bit) - Expected        511.9, actual    531 (1.04x) (20)
+Testing collisions (high 24-36 bits) - Worst is 33 bits: 266/255 (1.04x)
+Testing collisions (low  32-bit) - Expected        511.9, actual    580 (1.13x) (69)
+Testing collisions (low  24-36 bits) - Worst is 36 bits: 42/31 (1.31x)
+Testing distribution - Worst bias is the 17-bit window at bit 32 - 0.061%
 
 Testing bit 19
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected        511.9, actual    522 (1.02x) (11)
-Testing collisions (high 24-36 bits) - Worst is 33 bits: 264/255 (1.03x)
-Testing collisions (low  32-bit) - Expected        511.9, actual    559 (1.09x) (48)
-Testing collisions (low  24-36 bits) - Worst is 33 bits: 281/255 (1.10x)
-Testing distribution - Worst bias is the 18-bit window at bit 20 - 0.089%
+Testing collisions (high 32-bit) - Expected        511.9, actual    523 (1.02x) (12)
+Testing collisions (high 24-36 bits) - Worst is 36 bits: 37/31 (1.16x)
+Testing collisions (low  32-bit) - Expected        511.9, actual    522 (1.02x) (11)
+Testing collisions (low  24-36 bits) - Worst is 35 bits: 78/63 (1.22x)
+Testing distribution - Worst bias is the 18-bit window at bit 60 - 0.080%
 
 Testing bit 20
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected        511.9, actual    547 (1.07x) (36)
-Testing collisions (high 24-36 bits) - Worst is 35 bits: 71/63 (1.11x)
-Testing collisions (low  32-bit) - Expected        511.9, actual    524 (1.02x) (13)
-Testing collisions (low  24-36 bits) - Worst is 34 bits: 139/127 (1.09x)
-Testing distribution - Worst bias is the 18-bit window at bit 27 - 0.064%
+Testing collisions (high 32-bit) - Expected        511.9, actual    469 (0.92x)
+Testing collisions (high 24-36 bits) - Worst is 27 bits: 16203/16298 (0.99x)
+Testing collisions (low  32-bit) - Expected        511.9, actual    538 (1.05x) (27)
+Testing collisions (low  24-36 bits) - Worst is 36 bits: 38/31 (1.19x)
+Testing distribution - Worst bias is the 18-bit window at bit 15 - 0.089%
 
 Testing bit 21
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected        511.9, actual    487 (0.95x)
-Testing collisions (high 24-36 bits) - Worst is 34 bits: 135/127 (1.05x)
-Testing collisions (low  32-bit) - Expected        511.9, actual    510 (1.00x) (-1)
-Testing collisions (low  24-36 bits) - Worst is 35 bits: 69/63 (1.08x)
-Testing distribution - Worst bias is the 18-bit window at bit 34 - 0.091%
+Testing collisions (high 32-bit) - Expected        511.9, actual    551 (1.08x) (40)
+Testing collisions (high 24-36 bits) - Worst is 36 bits: 38/31 (1.19x)
+Testing collisions (low  32-bit) - Expected        511.9, actual    518 (1.01x) (7)
+Testing collisions (low  24-36 bits) - Worst is 32 bits: 518/511 (1.01x)
+Testing distribution - Worst bias is the 18-bit window at bit  6 - 0.061%
 
 Testing bit 22
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected        511.9, actual    517 (1.01x) (6)
-Testing collisions (high 24-36 bits) - Worst is 33 bits: 269/255 (1.05x)
-Testing collisions (low  32-bit) - Expected        511.9, actual    490 (0.96x)
-Testing collisions (low  24-36 bits) - Worst is 29 bits: 4116/4090 (1.01x)
-Testing distribution - Worst bias is the 18-bit window at bit 55 - 0.120%
+Testing collisions (high 32-bit) - Expected        511.9, actual    493 (0.96x)
+Testing collisions (high 24-36 bits) - Worst is 36 bits: 38/31 (1.19x)
+Testing collisions (low  32-bit) - Expected        511.9, actual    532 (1.04x) (21)
+Testing collisions (low  24-36 bits) - Worst is 36 bits: 36/31 (1.13x)
+Testing distribution - Worst bias is the 18-bit window at bit 58 - 0.075%
 
 Testing bit 23
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected        511.9, actual    480 (0.94x)
-Testing collisions (high 24-36 bits) - Worst is 36 bits: 33/31 (1.03x)
-Testing collisions (low  32-bit) - Expected        511.9, actual    508 (0.99x) (-3)
-Testing collisions (low  24-36 bits) - Worst is 30 bits: 2076/2046 (1.01x)
-Testing distribution - Worst bias is the 18-bit window at bit  5 - 0.060%
+Testing collisions (high 32-bit) - Expected        511.9, actual    517 (1.01x) (6)
+Testing collisions (high 24-36 bits) - Worst is 30 bits: 2075/2046 (1.01x)
+Testing collisions (low  32-bit) - Expected        511.9, actual    522 (1.02x) (11)
+Testing collisions (low  24-36 bits) - Worst is 36 bits: 43/31 (1.34x)
+Testing distribution - Worst bias is the 18-bit window at bit 15 - 0.071%
 
 Testing bit 24
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected        511.9, actual    493 (0.96x)
-Testing collisions (high 24-36 bits) - Worst is 36 bits: 39/31 (1.22x)
-Testing collisions (low  32-bit) - Expected        511.9, actual    492 (0.96x)
-Testing collisions (low  24-36 bits) - Worst is 30 bits: 2079/2046 (1.02x)
-Testing distribution - Worst bias is the 18-bit window at bit 54 - 0.078%
+Testing collisions (high 32-bit) - Expected        511.9, actual    513 (1.00x) (2)
+Testing collisions (high 24-36 bits) - Worst is 36 bits: 42/31 (1.31x)
+Testing collisions (low  32-bit) - Expected        511.9, actual    488 (0.95x)
+Testing collisions (low  24-36 bits) - Worst is 34 bits: 137/127 (1.07x)
+Testing distribution - Worst bias is the 18-bit window at bit  4 - 0.078%
 
 Testing bit 25
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected        511.9, actual    511 (1.00x)
-Testing collisions (high 24-36 bits) - Worst is 35 bits: 65/63 (1.02x)
-Testing collisions (low  32-bit) - Expected        511.9, actual    493 (0.96x)
-Testing collisions (low  24-36 bits) - Worst is 36 bits: 33/31 (1.03x)
-Testing distribution - Worst bias is the 18-bit window at bit  7 - 0.093%
+Testing collisions (high 32-bit) - Expected        511.9, actual    513 (1.00x) (2)
+Testing collisions (high 24-36 bits) - Worst is 36 bits: 39/31 (1.22x)
+Testing collisions (low  32-bit) - Expected        511.9, actual    570 (1.11x) (59)
+Testing collisions (low  24-36 bits) - Worst is 34 bits: 144/127 (1.13x)
+Testing distribution - Worst bias is the 18-bit window at bit 50 - 0.072%
 
 Testing bit 26
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected        511.9, actual    533 (1.04x) (22)
-Testing collisions (high 24-36 bits) - Worst is 35 bits: 71/63 (1.11x)
-Testing collisions (low  32-bit) - Expected        511.9, actual    514 (1.00x) (3)
-Testing collisions (low  24-36 bits) - Worst is 30 bits: 2088/2046 (1.02x)
-Testing distribution - Worst bias is the 18-bit window at bit 33 - 0.084%
+Testing collisions (high 32-bit) - Expected        511.9, actual    514 (1.00x) (3)
+Testing collisions (high 24-36 bits) - Worst is 29 bits: 4166/4090 (1.02x)
+Testing collisions (low  32-bit) - Expected        511.9, actual    528 (1.03x) (17)
+Testing collisions (low  24-36 bits) - Worst is 36 bits: 41/31 (1.28x)
+Testing distribution - Worst bias is the 18-bit window at bit 59 - 0.082%
 
 Testing bit 27
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected        511.9, actual    456 (0.89x)
-Testing collisions (high 24-36 bits) - Worst is 29 bits: 4111/4090 (1.00x)
-Testing collisions (low  32-bit) - Expected        511.9, actual    519 (1.01x) (8)
-Testing collisions (low  24-36 bits) - Worst is 31 bits: 1054/1023 (1.03x)
-Testing distribution - Worst bias is the 18-bit window at bit 24 - 0.074%
+Testing collisions (high 32-bit) - Expected        511.9, actual    477 (0.93x)
+Testing collisions (high 24-36 bits) - Worst is 33 bits: 261/255 (1.02x)
+Testing collisions (low  32-bit) - Expected        511.9, actual    542 (1.06x) (31)
+Testing collisions (low  24-36 bits) - Worst is 35 bits: 90/63 (1.41x)
+Testing distribution - Worst bias is the 18-bit window at bit  3 - 0.058%
 
 Testing bit 28
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected        511.9, actual    528 (1.03x) (17)
-Testing collisions (high 24-36 bits) - Worst is 33 bits: 274/255 (1.07x)
-Testing collisions (low  32-bit) - Expected        511.9, actual    490 (0.96x)
-Testing collisions (low  24-36 bits) - Worst is 35 bits: 80/63 (1.25x)
-Testing distribution - Worst bias is the 18-bit window at bit 40 - 0.097%
+Testing collisions (high 32-bit) - Expected        511.9, actual    475 (0.93x)
+Testing collisions (high 24-36 bits) - Worst is 36 bits: 36/31 (1.13x)
+Testing collisions (low  32-bit) - Expected        511.9, actual    521 (1.02x) (10)
+Testing collisions (low  24-36 bits) - Worst is 35 bits: 76/63 (1.19x)
+Testing distribution - Worst bias is the 18-bit window at bit 40 - 0.056%
 
 Testing bit 29
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected        511.9, actual    491 (0.96x)
-Testing collisions (high 24-36 bits) - Worst is 27 bits: 16375/16298 (1.00x)
-Testing collisions (low  32-bit) - Expected        511.9, actual    505 (0.99x) (-6)
-Testing collisions (low  24-36 bits) - Worst is 24 bits: 125841/125777 (1.00x)
-Testing distribution - Worst bias is the 18-bit window at bit  3 - 0.067%
+Testing collisions (high 32-bit) - Expected        511.9, actual    485 (0.95x)
+Testing collisions (high 24-36 bits) - Worst is 35 bits: 68/63 (1.06x)
+Testing collisions (low  32-bit) - Expected        511.9, actual    533 (1.04x) (22)
+Testing collisions (low  24-36 bits) - Worst is 34 bits: 148/127 (1.16x)
+Testing distribution - Worst bias is the 18-bit window at bit  5 - 0.094%
 
 Testing bit 30
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
 Testing collisions (high 32-bit) - Expected        511.9, actual    512 (1.00x) (1)
-Testing collisions (high 24-36 bits) - Worst is 34 bits: 142/127 (1.11x)
-Testing collisions (low  32-bit) - Expected        511.9, actual    497 (0.97x)
-Testing collisions (low  24-36 bits) - Worst is 34 bits: 134/127 (1.05x)
-Testing distribution - Worst bias is the 18-bit window at bit  9 - 0.062%
+Testing collisions (high 24-36 bits) - Worst is 34 bits: 138/127 (1.08x)
+Testing collisions (low  32-bit) - Expected        511.9, actual    531 (1.04x) (20)
+Testing collisions (low  24-36 bits) - Worst is 34 bits: 137/127 (1.07x)
+Testing distribution - Worst bias is the 18-bit window at bit 47 - 0.065%
 
 Testing bit 31
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected        511.9, actual    475 (0.93x)
-Testing collisions (high 24-36 bits) - Worst is 36 bits: 38/31 (1.19x)
-Testing collisions (low  32-bit) - Expected        511.9, actual    523 (1.02x) (12)
-Testing collisions (low  24-36 bits) - Worst is 34 bits: 146/127 (1.14x)
-Testing distribution - Worst bias is the 18-bit window at bit 48 - 0.071%
+Testing collisions (high 32-bit) - Expected        511.9, actual    482 (0.94x)
+Testing collisions (high 24-36 bits) - Worst is 25 bits: 64038/64191 (1.00x)
+Testing collisions (low  32-bit) - Expected        511.9, actual    549 (1.07x) (38)
+Testing collisions (low  24-36 bits) - Worst is 33 bits: 277/255 (1.08x)
+Testing distribution - Worst bias is the 18-bit window at bit 21 - 0.108%
 
 Testing bit 32
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected        511.9, actual    485 (0.95x)
-Testing collisions (high 24-36 bits) - Worst is 36 bits: 35/31 (1.09x)
-Testing collisions (low  32-bit) - Expected        511.9, actual    568 (1.11x) (57)
-Testing collisions (low  24-36 bits) - Worst is 36 bits: 39/31 (1.22x)
-Testing distribution - Worst bias is the 18-bit window at bit  8 - 0.068%
+Testing collisions (high 32-bit) - Expected        511.9, actual    536 (1.05x) (25)
+Testing collisions (high 24-36 bits) - Worst is 34 bits: 146/127 (1.14x)
+Testing collisions (low  32-bit) - Expected        511.9, actual    584 (1.14x) (73)
+Testing collisions (low  24-36 bits) - Worst is 36 bits: 46/31 (1.44x)
+Testing distribution - Worst bias is the 18-bit window at bit 57 - 0.129%
 
 Testing bit 33
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected        511.9, actual    537 (1.05x) (26)
-Testing collisions (high 24-36 bits) - Worst is 32 bits: 537/511 (1.05x)
-Testing collisions (low  32-bit) - Expected        511.9, actual    556 (1.09x) (45)
-Testing collisions (low  24-36 bits) - Worst is 34 bits: 145/127 (1.13x)
-Testing distribution - Worst bias is the 18-bit window at bit 55 - 0.080%
+Testing collisions (high 32-bit) - Expected        511.9, actual    490 (0.96x)
+Testing collisions (high 24-36 bits) - Worst is 35 bits: 69/63 (1.08x)
+Testing collisions (low  32-bit) - Expected        511.9, actual    517 (1.01x) (6)
+Testing collisions (low  24-36 bits) - Worst is 33 bits: 268/255 (1.05x)
+Testing distribution - Worst bias is the 18-bit window at bit 33 - 0.073%
 
 Testing bit 34
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected        511.9, actual    498 (0.97x)
-Testing collisions (high 24-36 bits) - Worst is 36 bits: 38/31 (1.19x)
-Testing collisions (low  32-bit) - Expected        511.9, actual    514 (1.00x) (3)
-Testing collisions (low  24-36 bits) - Worst is 36 bits: 45/31 (1.41x)
-Testing distribution - Worst bias is the 18-bit window at bit 22 - 0.065%
+Testing collisions (high 32-bit) - Expected        511.9, actual    452 (0.88x)
+Testing collisions (high 24-36 bits) - Worst is 26 bits: 32421/32429 (1.00x)
+Testing collisions (low  32-bit) - Expected        511.9, actual    505 (0.99x) (-6)
+Testing collisions (low  24-36 bits) - Worst is 36 bits: 33/31 (1.03x)
+Testing distribution - Worst bias is the 18-bit window at bit  4 - 0.097%
 
 Testing bit 35
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected        511.9, actual    514 (1.00x) (3)
-Testing collisions (high 24-36 bits) - Worst is 36 bits: 34/31 (1.06x)
-Testing collisions (low  32-bit) - Expected        511.9, actual    521 (1.02x) (10)
-Testing collisions (low  24-36 bits) - Worst is 36 bits: 44/31 (1.38x)
-Testing distribution - Worst bias is the 18-bit window at bit 28 - 0.081%
+Testing collisions (high 32-bit) - Expected        511.9, actual    466 (0.91x)
+Testing collisions (high 24-36 bits) - Worst is 28 bits: 8249/8170 (1.01x)
+Testing collisions (low  32-bit) - Expected        511.9, actual    573 (1.12x) (62)
+Testing collisions (low  24-36 bits) - Worst is 36 bits: 42/31 (1.31x)
+Testing distribution - Worst bias is the 18-bit window at bit 15 - 0.075%
 
 Testing bit 36
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected        511.9, actual    575 (1.12x) (64)
-Testing collisions (high 24-36 bits) - Worst is 32 bits: 575/511 (1.12x)
-Testing collisions (low  32-bit) - Expected        511.9, actual    548 (1.07x) (37)
-Testing collisions (low  24-36 bits) - Worst is 32 bits: 548/511 (1.07x)
-Testing distribution - Worst bias is the 18-bit window at bit 28 - 0.080%
+Testing collisions (high 32-bit) - Expected        511.9, actual    506 (0.99x) (-5)
+Testing collisions (high 24-36 bits) - Worst is 35 bits: 66/63 (1.03x)
+Testing collisions (low  32-bit) - Expected        511.9, actual    515 (1.01x) (4)
+Testing collisions (low  24-36 bits) - Worst is 32 bits: 515/511 (1.01x)
+Testing distribution - Worst bias is the 18-bit window at bit 33 - 0.078%
 
 Testing bit 37
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected        511.9, actual    553 (1.08x) (42)
-Testing collisions (high 24-36 bits) - Worst is 33 bits: 303/255 (1.18x)
-Testing collisions (low  32-bit) - Expected        511.9, actual    469 (0.92x)
-Testing collisions (low  24-36 bits) - Worst is 29 bits: 4183/4090 (1.02x)
-Testing distribution - Worst bias is the 18-bit window at bit 44 - 0.076%
+Testing collisions (high 32-bit) - Expected        511.9, actual    565 (1.10x) (54)
+Testing collisions (high 24-36 bits) - Worst is 33 bits: 288/255 (1.13x)
+Testing collisions (low  32-bit) - Expected        511.9, actual    493 (0.96x)
+Testing collisions (low  24-36 bits) - Worst is 36 bits: 42/31 (1.31x)
+Testing distribution - Worst bias is the 18-bit window at bit 31 - 0.069%
 
 Testing bit 38
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected        511.9, actual    495 (0.97x)
-Testing collisions (high 24-36 bits) - Worst is 35 bits: 66/63 (1.03x)
-Testing collisions (low  32-bit) - Expected        511.9, actual    524 (1.02x) (13)
-Testing collisions (low  24-36 bits) - Worst is 36 bits: 35/31 (1.09x)
-Testing distribution - Worst bias is the 18-bit window at bit  7 - 0.067%
+Testing collisions (high 32-bit) - Expected        511.9, actual    541 (1.06x) (30)
+Testing collisions (high 24-36 bits) - Worst is 34 bits: 151/127 (1.18x)
+Testing collisions (low  32-bit) - Expected        511.9, actual    505 (0.99x) (-6)
+Testing collisions (low  24-36 bits) - Worst is 36 bits: 37/31 (1.16x)
+Testing distribution - Worst bias is the 18-bit window at bit 58 - 0.077%
 
 Testing bit 39
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected        511.9, actual    480 (0.94x)
-Testing collisions (high 24-36 bits) - Worst is 24 bits: 125741/125777 (1.00x)
-Testing collisions (low  32-bit) - Expected        511.9, actual    542 (1.06x) (31)
-Testing collisions (low  24-36 bits) - Worst is 35 bits: 73/63 (1.14x)
-Testing distribution - Worst bias is the 17-bit window at bit  0 - 0.053%
+Testing collisions (high 32-bit) - Expected        511.9, actual    502 (0.98x) (-9)
+Testing collisions (high 24-36 bits) - Worst is 35 bits: 70/63 (1.09x)
+Testing collisions (low  32-bit) - Expected        511.9, actual    510 (1.00x) (-1)
+Testing collisions (low  24-36 bits) - Worst is 36 bits: 34/31 (1.06x)
+Testing distribution - Worst bias is the 18-bit window at bit 17 - 0.070%
 
 Testing bit 40
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected        511.9, actual    523 (1.02x) (12)
-Testing collisions (high 24-36 bits) - Worst is 35 bits: 67/63 (1.05x)
-Testing collisions (low  32-bit) - Expected        511.9, actual    523 (1.02x) (12)
-Testing collisions (low  24-36 bits) - Worst is 35 bits: 71/63 (1.11x)
-Testing distribution - Worst bias is the 18-bit window at bit 18 - 0.098%
+Testing collisions (high 32-bit) - Expected        511.9, actual    508 (0.99x) (-3)
+Testing collisions (high 24-36 bits) - Worst is 36 bits: 46/31 (1.44x)
+Testing collisions (low  32-bit) - Expected        511.9, actual    494 (0.97x)
+Testing collisions (low  24-36 bits) - Worst is 36 bits: 34/31 (1.06x)
+Testing distribution - Worst bias is the 18-bit window at bit  1 - 0.067%
 
 Testing bit 41
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected        511.9, actual    520 (1.02x) (9)
-Testing collisions (high 24-36 bits) - Worst is 36 bits: 34/31 (1.06x)
-Testing collisions (low  32-bit) - Expected        511.9, actual    519 (1.01x) (8)
-Testing collisions (low  24-36 bits) - Worst is 35 bits: 71/63 (1.11x)
-Testing distribution - Worst bias is the 18-bit window at bit 44 - 0.072%
+Testing collisions (high 32-bit) - Expected        511.9, actual    513 (1.00x) (2)
+Testing collisions (high 24-36 bits) - Worst is 29 bits: 4142/4090 (1.01x)
+Testing collisions (low  32-bit) - Expected        511.9, actual    542 (1.06x) (31)
+Testing collisions (low  24-36 bits) - Worst is 36 bits: 45/31 (1.41x)
+Testing distribution - Worst bias is the 18-bit window at bit 15 - 0.061%
 
 Testing bit 42
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected        511.9, actual    503 (0.98x) (-8)
-Testing collisions (high 24-36 bits) - Worst is 36 bits: 40/31 (1.25x)
-Testing collisions (low  32-bit) - Expected        511.9, actual    531 (1.04x) (20)
-Testing collisions (low  24-36 bits) - Worst is 33 bits: 273/255 (1.07x)
-Testing distribution - Worst bias is the 18-bit window at bit  4 - 0.072%
+Testing collisions (high 32-bit) - Expected        511.9, actual    494 (0.97x)
+Testing collisions (high 24-36 bits) - Worst is 24 bits: 125202/125777 (1.00x)
+Testing collisions (low  32-bit) - Expected        511.9, actual    546 (1.07x) (35)
+Testing collisions (low  24-36 bits) - Worst is 32 bits: 546/511 (1.07x)
+Testing distribution - Worst bias is the 18-bit window at bit 24 - 0.075%
 
 Testing bit 43
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected        511.9, actual    546 (1.07x) (35)
-Testing collisions (high 24-36 bits) - Worst is 33 bits: 287/255 (1.12x)
-Testing collisions (low  32-bit) - Expected        511.9, actual    480 (0.94x)
-Testing collisions (low  24-36 bits) - Worst is 34 bits: 133/127 (1.04x)
-Testing distribution - Worst bias is the 18-bit window at bit 43 - 0.073%
+Testing collisions (high 32-bit) - Expected        511.9, actual    513 (1.00x) (2)
+Testing collisions (high 24-36 bits) - Worst is 35 bits: 74/63 (1.16x)
+Testing collisions (low  32-bit) - Expected        511.9, actual    552 (1.08x) (41)
+Testing collisions (low  24-36 bits) - Worst is 34 bits: 148/127 (1.16x)
+Testing distribution - Worst bias is the 18-bit window at bit  6 - 0.087%
 
 Testing bit 44
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected        511.9, actual    530 (1.04x) (19)
-Testing collisions (high 24-36 bits) - Worst is 36 bits: 40/31 (1.25x)
-Testing collisions (low  32-bit) - Expected        511.9, actual    510 (1.00x) (-1)
-Testing collisions (low  24-36 bits) - Worst is 27 bits: 16377/16298 (1.00x)
-Testing distribution - Worst bias is the 18-bit window at bit 27 - 0.057%
+Testing collisions (high 32-bit) - Expected        511.9, actual    496 (0.97x)
+Testing collisions (high 24-36 bits) - Worst is 35 bits: 69/63 (1.08x)
+Testing collisions (low  32-bit) - Expected        511.9, actual    552 (1.08x) (41)
+Testing collisions (low  24-36 bits) - Worst is 34 bits: 146/127 (1.14x)
+Testing distribution - Worst bias is the 18-bit window at bit 44 - 0.047%
 
 Testing bit 45
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected        511.9, actual    510 (1.00x) (-1)
-Testing collisions (high 24-36 bits) - Worst is 26 bits: 32880/32429 (1.01x)
-Testing collisions (low  32-bit) - Expected        511.9, actual    525 (1.03x) (14)
-Testing collisions (low  24-36 bits) - Worst is 36 bits: 39/31 (1.22x)
-Testing distribution - Worst bias is the 18-bit window at bit 35 - 0.076%
+Testing collisions (high 32-bit) - Expected        511.9, actual    500 (0.98x)
+Testing collisions (high 24-36 bits) - Worst is 36 bits: 35/31 (1.09x)
+Testing collisions (low  32-bit) - Expected        511.9, actual    520 (1.02x) (9)
+Testing collisions (low  24-36 bits) - Worst is 34 bits: 136/127 (1.06x)
+Testing distribution - Worst bias is the 18-bit window at bit 48 - 0.058%
 
 Testing bit 46
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected        511.9, actual    513 (1.00x) (2)
-Testing collisions (high 24-36 bits) - Worst is 36 bits: 34/31 (1.06x)
-Testing collisions (low  32-bit) - Expected        511.9, actual    573 (1.12x) (62)
-Testing collisions (low  24-36 bits) - Worst is 36 bits: 40/31 (1.25x)
-Testing distribution - Worst bias is the 17-bit window at bit 53 - 0.061%
+Testing collisions (high 32-bit) - Expected        511.9, actual    530 (1.04x) (19)
+Testing collisions (high 24-36 bits) - Worst is 33 bits: 272/255 (1.06x)
+Testing collisions (low  32-bit) - Expected        511.9, actual    549 (1.07x) (38)
+Testing collisions (low  24-36 bits) - Worst is 35 bits: 75/63 (1.17x)
+Testing distribution - Worst bias is the 18-bit window at bit 28 - 0.052%
 
 Testing bit 47
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected        511.9, actual    503 (0.98x) (-8)
-Testing collisions (high 24-36 bits) - Worst is 30 bits: 2078/2046 (1.02x)
-Testing collisions (low  32-bit) - Expected        511.9, actual    475 (0.93x)
-Testing collisions (low  24-36 bits) - Worst is 24 bits: 125854/125777 (1.00x)
-Testing distribution - Worst bias is the 18-bit window at bit  7 - 0.077%
+Testing collisions (high 32-bit) - Expected        511.9, actual    559 (1.09x) (48)
+Testing collisions (high 24-36 bits) - Worst is 35 bits: 76/63 (1.19x)
+Testing collisions (low  32-bit) - Expected        511.9, actual    476 (0.93x)
+Testing collisions (low  24-36 bits) - Worst is 24 bits: 126098/125777 (1.00x)
+Testing distribution - Worst bias is the 18-bit window at bit 57 - 0.094%
 
 Testing bit 48
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected        511.9, actual    511 (1.00x)
-Testing collisions (high 24-36 bits) - Worst is 35 bits: 67/63 (1.05x)
-Testing collisions (low  32-bit) - Expected        511.9, actual    487 (0.95x)
-Testing collisions (low  24-36 bits) - Worst is 35 bits: 65/63 (1.02x)
-Testing distribution - Worst bias is the 18-bit window at bit 57 - 0.075%
+Testing collisions (high 32-bit) - Expected        511.9, actual    515 (1.01x) (4)
+Testing collisions (high 24-36 bits) - Worst is 36 bits: 37/31 (1.16x)
+Testing collisions (low  32-bit) - Expected        511.9, actual    502 (0.98x) (-9)
+Testing collisions (low  24-36 bits) - Worst is 34 bits: 131/127 (1.02x)
+Testing distribution - Worst bias is the 18-bit window at bit  0 - 0.093%
 
 Testing bit 49
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected        511.9, actual    530 (1.04x) (19)
-Testing collisions (high 24-36 bits) - Worst is 36 bits: 34/31 (1.06x)
-Testing collisions (low  32-bit) - Expected        511.9, actual    530 (1.04x) (19)
-Testing collisions (low  24-36 bits) - Worst is 30 bits: 2125/2046 (1.04x)
-Testing distribution - Worst bias is the 18-bit window at bit 55 - 0.071%
+Testing collisions (high 32-bit) - Expected        511.9, actual    557 (1.09x) (46)
+Testing collisions (high 24-36 bits) - Worst is 34 bits: 145/127 (1.13x)
+Testing collisions (low  32-bit) - Expected        511.9, actual    533 (1.04x) (22)
+Testing collisions (low  24-36 bits) - Worst is 36 bits: 37/31 (1.16x)
+Testing distribution - Worst bias is the 18-bit window at bit 37 - 0.088%
 
 Testing bit 50
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected        511.9, actual    548 (1.07x) (37)
-Testing collisions (high 24-36 bits) - Worst is 36 bits: 37/31 (1.16x)
-Testing collisions (low  32-bit) - Expected        511.9, actual    560 (1.09x) (49)
-Testing collisions (low  24-36 bits) - Worst is 34 bits: 144/127 (1.13x)
-Testing distribution - Worst bias is the 18-bit window at bit  7 - 0.123%
+Testing collisions (high 32-bit) - Expected        511.9, actual    513 (1.00x) (2)
+Testing collisions (high 24-36 bits) - Worst is 36 bits: 35/31 (1.09x)
+Testing collisions (low  32-bit) - Expected        511.9, actual    531 (1.04x) (20)
+Testing collisions (low  24-36 bits) - Worst is 36 bits: 44/31 (1.38x)
+Testing distribution - Worst bias is the 18-bit window at bit 25 - 0.096%
 
 Testing bit 51
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected        511.9, actual    533 (1.04x) (22)
-Testing collisions (high 24-36 bits) - Worst is 35 bits: 74/63 (1.16x)
-Testing collisions (low  32-bit) - Expected        511.9, actual    520 (1.02x) (9)
-Testing collisions (low  24-36 bits) - Worst is 29 bits: 4156/4090 (1.02x)
-Testing distribution - Worst bias is the 18-bit window at bit 59 - 0.070%
+Testing collisions (high 32-bit) - Expected        511.9, actual    495 (0.97x)
+Testing collisions (high 24-36 bits) - Worst is 29 bits: 4185/4090 (1.02x)
+Testing collisions (low  32-bit) - Expected        511.9, actual    510 (1.00x) (-1)
+Testing collisions (low  24-36 bits) - Worst is 36 bits: 44/31 (1.38x)
+Testing distribution - Worst bias is the 18-bit window at bit 54 - 0.064%
 
 Testing bit 52
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected        511.9, actual    489 (0.96x)
-Testing collisions (high 24-36 bits) - Worst is 30 bits: 2066/2046 (1.01x)
-Testing collisions (low  32-bit) - Expected        511.9, actual    503 (0.98x) (-8)
-Testing collisions (low  24-36 bits) - Worst is 26 bits: 32529/32429 (1.00x)
-Testing distribution - Worst bias is the 18-bit window at bit 42 - 0.084%
+Testing collisions (high 32-bit) - Expected        511.9, actual    525 (1.03x) (14)
+Testing collisions (high 24-36 bits) - Worst is 32 bits: 525/511 (1.03x)
+Testing collisions (low  32-bit) - Expected        511.9, actual    494 (0.97x)
+Testing collisions (low  24-36 bits) - Worst is 36 bits: 39/31 (1.22x)
+Testing distribution - Worst bias is the 18-bit window at bit 39 - 0.085%
 
 Testing bit 53
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected        511.9, actual    527 (1.03x) (16)
-Testing collisions (high 24-36 bits) - Worst is 30 bits: 2145/2046 (1.05x)
-Testing collisions (low  32-bit) - Expected        511.9, actual    504 (0.98x) (-7)
-Testing collisions (low  24-36 bits) - Worst is 26 bits: 32595/32429 (1.01x)
-Testing distribution - Worst bias is the 18-bit window at bit 46 - 0.084%
+Testing collisions (high 32-bit) - Expected        511.9, actual    509 (0.99x) (-2)
+Testing collisions (high 24-36 bits) - Worst is 36 bits: 39/31 (1.22x)
+Testing collisions (low  32-bit) - Expected        511.9, actual    510 (1.00x) (-1)
+Testing collisions (low  24-36 bits) - Worst is 35 bits: 72/63 (1.13x)
+Testing distribution - Worst bias is the 18-bit window at bit 29 - 0.101%
 
 Testing bit 54
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected        511.9, actual    515 (1.01x) (4)
-Testing collisions (high 24-36 bits) - Worst is 35 bits: 71/63 (1.11x)
-Testing collisions (low  32-bit) - Expected        511.9, actual    540 (1.05x) (29)
-Testing collisions (low  24-36 bits) - Worst is 34 bits: 153/127 (1.20x)
-Testing distribution - Worst bias is the 18-bit window at bit 18 - 0.089%
+Testing collisions (high 32-bit) - Expected        511.9, actual    540 (1.05x) (29)
+Testing collisions (high 24-36 bits) - Worst is 32 bits: 540/511 (1.05x)
+Testing collisions (low  32-bit) - Expected        511.9, actual    531 (1.04x) (20)
+Testing collisions (low  24-36 bits) - Worst is 35 bits: 72/63 (1.13x)
+Testing distribution - Worst bias is the 18-bit window at bit 48 - 0.071%
 
 Testing bit 55
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected        511.9, actual    551 (1.08x) (40)
-Testing collisions (high 24-36 bits) - Worst is 35 bits: 77/63 (1.20x)
-Testing collisions (low  32-bit) - Expected        511.9, actual    529 (1.03x) (18)
-Testing collisions (low  24-36 bits) - Worst is 32 bits: 529/511 (1.03x)
-Testing distribution - Worst bias is the 18-bit window at bit 24 - 0.118%
+Testing collisions (high 32-bit) - Expected        511.9, actual    510 (1.00x) (-1)
+Testing collisions (high 24-36 bits) - Worst is 34 bits: 131/127 (1.02x)
+Testing collisions (low  32-bit) - Expected        511.9, actual    504 (0.98x) (-7)
+Testing collisions (low  24-36 bits) - Worst is 26 bits: 32368/32429 (1.00x)
+Testing distribution - Worst bias is the 18-bit window at bit 62 - 0.079%
 
 Testing bit 56
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected        511.9, actual    513 (1.00x) (2)
-Testing collisions (high 24-36 bits) - Worst is 36 bits: 42/31 (1.31x)
-Testing collisions (low  32-bit) - Expected        511.9, actual    489 (0.96x)
-Testing collisions (low  24-36 bits) - Worst is 30 bits: 2079/2046 (1.02x)
-Testing distribution - Worst bias is the 18-bit window at bit 58 - 0.104%
+Testing collisions (high 32-bit) - Expected        511.9, actual    491 (0.96x)
+Testing collisions (high 24-36 bits) - Worst is 31 bits: 1044/1023 (1.02x)
+Testing collisions (low  32-bit) - Expected        511.9, actual    500 (0.98x)
+Testing collisions (low  24-36 bits) - Worst is 34 bits: 136/127 (1.06x)
+Testing distribution - Worst bias is the 18-bit window at bit  8 - 0.110%
 
 Testing bit 57
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected        511.9, actual    516 (1.01x) (5)
-Testing collisions (high 24-36 bits) - Worst is 36 bits: 44/31 (1.38x)
-Testing collisions (low  32-bit) - Expected        511.9, actual    526 (1.03x) (15)
-Testing collisions (low  24-36 bits) - Worst is 34 bits: 146/127 (1.14x)
-Testing distribution - Worst bias is the 18-bit window at bit 24 - 0.101%
+Testing collisions (high 32-bit) - Expected        511.9, actual    493 (0.96x)
+Testing collisions (high 24-36 bits) - Worst is 35 bits: 75/63 (1.17x)
+Testing collisions (low  32-bit) - Expected        511.9, actual    532 (1.04x) (21)
+Testing collisions (low  24-36 bits) - Worst is 36 bits: 35/31 (1.09x)
+Testing distribution - Worst bias is the 18-bit window at bit  6 - 0.043%
 
 Testing bit 58
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected        511.9, actual    562 (1.10x) (51)
-Testing collisions (high 24-36 bits) - Worst is 33 bits: 290/255 (1.13x)
-Testing collisions (low  32-bit) - Expected        511.9, actual    549 (1.07x) (38)
-Testing collisions (low  24-36 bits) - Worst is 32 bits: 549/511 (1.07x)
-Testing distribution - Worst bias is the 18-bit window at bit  3 - 0.080%
+Testing collisions (high 32-bit) - Expected        511.9, actual    493 (0.96x)
+Testing collisions (high 24-36 bits) - Worst is 27 bits: 16608/16298 (1.02x)
+Testing collisions (low  32-bit) - Expected        511.9, actual    525 (1.03x) (14)
+Testing collisions (low  24-36 bits) - Worst is 34 bits: 142/127 (1.11x)
+Testing distribution - Worst bias is the 18-bit window at bit 14 - 0.079%
 
 Testing bit 59
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected        511.9, actual    501 (0.98x)
-Testing collisions (high 24-36 bits) - Worst is 34 bits: 133/127 (1.04x)
-Testing collisions (low  32-bit) - Expected        511.9, actual    516 (1.01x) (5)
-Testing collisions (low  24-36 bits) - Worst is 34 bits: 143/127 (1.12x)
-Testing distribution - Worst bias is the 18-bit window at bit 30 - 0.076%
+Testing collisions (high 32-bit) - Expected        511.9, actual    521 (1.02x) (10)
+Testing collisions (high 24-36 bits) - Worst is 36 bits: 35/31 (1.09x)
+Testing collisions (low  32-bit) - Expected        511.9, actual    511 (1.00x)
+Testing collisions (low  24-36 bits) - Worst is 31 bits: 1054/1023 (1.03x)
+Testing distribution - Worst bias is the 18-bit window at bit 43 - 0.099%
 
 Testing bit 60
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected        511.9, actual    509 (0.99x) (-2)
-Testing collisions (high 24-36 bits) - Worst is 34 bits: 129/127 (1.01x)
-Testing collisions (low  32-bit) - Expected        511.9, actual    537 (1.05x) (26)
-Testing collisions (low  24-36 bits) - Worst is 34 bits: 142/127 (1.11x)
-Testing distribution - Worst bias is the 18-bit window at bit 41 - 0.104%
+Testing collisions (high 32-bit) - Expected        511.9, actual    489 (0.96x)
+Testing collisions (high 24-36 bits) - Worst is 36 bits: 35/31 (1.09x)
+Testing collisions (low  32-bit) - Expected        511.9, actual    512 (1.00x) (1)
+Testing collisions (low  24-36 bits) - Worst is 35 bits: 72/63 (1.13x)
+Testing distribution - Worst bias is the 18-bit window at bit 12 - 0.081%
 
 Testing bit 61
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected        511.9, actual    502 (0.98x) (-9)
-Testing collisions (high 24-36 bits) - Worst is 33 bits: 263/255 (1.03x)
-Testing collisions (low  32-bit) - Expected        511.9, actual    525 (1.03x) (14)
-Testing collisions (low  24-36 bits) - Worst is 35 bits: 66/63 (1.03x)
-Testing distribution - Worst bias is the 18-bit window at bit 60 - 0.089%
+Testing collisions (high 32-bit) - Expected        511.9, actual    494 (0.97x)
+Testing collisions (high 24-36 bits) - Worst is 36 bits: 36/31 (1.13x)
+Testing collisions (low  32-bit) - Expected        511.9, actual    508 (0.99x) (-3)
+Testing collisions (low  24-36 bits) - Worst is 31 bits: 1062/1023 (1.04x)
+Testing distribution - Worst bias is the 18-bit window at bit 50 - 0.081%
 
 Testing bit 62
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected        511.9, actual    541 (1.06x) (30)
-Testing collisions (high 24-36 bits) - Worst is 32 bits: 541/511 (1.06x)
-Testing collisions (low  32-bit) - Expected        511.9, actual    502 (0.98x) (-9)
-Testing collisions (low  24-36 bits) - Worst is 35 bits: 73/63 (1.14x)
-Testing distribution - Worst bias is the 18-bit window at bit  4 - 0.057%
+Testing collisions (high 32-bit) - Expected        511.9, actual    524 (1.02x) (13)
+Testing collisions (high 24-36 bits) - Worst is 32 bits: 524/511 (1.02x)
+Testing collisions (low  32-bit) - Expected        511.9, actual    498 (0.97x)
+Testing collisions (low  24-36 bits) - Worst is 36 bits: 33/31 (1.03x)
+Testing distribution - Worst bias is the 18-bit window at bit 54 - 0.063%
 
 Testing bit 63
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected        511.9, actual    479 (0.94x)
-Testing collisions (high 24-36 bits) - Worst is 36 bits: 37/31 (1.16x)
-Testing collisions (low  32-bit) - Expected        511.9, actual    562 (1.10x) (51)
-Testing collisions (low  24-36 bits) - Worst is 36 bits: 37/31 (1.16x)
-Testing distribution - Worst bias is the 18-bit window at bit 50 - 0.061%
+Testing collisions (high 32-bit) - Expected        511.9, actual    545 (1.06x) (34)
+Testing collisions (high 24-36 bits) - Worst is 33 bits: 277/255 (1.08x)
+Testing collisions (low  32-bit) - Expected        511.9, actual    499 (0.97x)
+Testing collisions (low  24-36 bits) - Worst is 36 bits: 36/31 (1.13x)
+Testing distribution - Worst bias is the 18-bit window at bit 50 - 0.051%
 
 
 [[[ MomentChi2 Tests ]]]
@@ -1103,16 +1103,16 @@ Testing distribution - Worst bias is the 18-bit window at bit 50 - 0.061%
 Analyze hashes produced from a serie of linearly increasing numbers of 32-bit, using a step of 2 ...
 Target values to approximate : 38918200.000000 - 273633.333333
 4 threads starting...  done
-Popcount 1 stats : 38919070.880649 - 273658.516930
-Popcount 0 stats : 38919194.839021 - 273657.339256
-MomentChi2 for bits 1 :   1.38579
-MomentChi2 for bits 0 :   1.80837
+Popcount 1 stats : 38919778.788079 - 273658.616603
+Popcount 0 stats : 38918384.825367 - 273648.377654
+MomentChi2 for bits 1 :   4.55437
+MomentChi2 for bits 0 :  0.0624183
 
 Derivative stats (transition from 2 consecutive values) :
-Popcount 1 stats : 38918610.739435 - 273628.413070
-Popcount 0 stats : 38919023.148389 - 273649.013652
-MomentChi2 for deriv b1 :  0.308275
-MomentChi2 for deriv b0 :   1.23807
+Popcount 1 stats : 38919174.788465 - 273677.376630
+Popcount 0 stats : 38918977.878709 - 273635.552771
+MomentChi2 for deriv b1 :   1.73615
+MomentChi2 for deriv b0 :   1.10566
 
   Great
 
@@ -1121,10 +1121,10 @@ MomentChi2 for deriv b0 :   1.23807
 
 Generating 33554432 random numbers :
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected     130731.3, actual 130656 (1.00x) (-75)
-Testing collisions (high 28-44 bits) - Worst is 43 bits: 66/63 (1.03x)
-Testing collisions (low  32-bit) - Expected     130731.3, actual 130961 (1.00x) (230)
-Testing collisions (low  28-44 bits) - Worst is 37 bits: 4145/4095 (1.01x)
+Testing collisions (high 32-bit) - Expected     130731.3, actual 130258 (1.00x) (-473)
+Testing collisions (high 28-44 bits) - Worst is 41 bits: 261/255 (1.02x)
+Testing collisions (low  32-bit) - Expected     130731.3, actual 130995 (1.00x) (264)
+Testing collisions (low  28-44 bits) - Worst is 40 bits: 529/511 (1.03x)
 
 [[[ BadSeeds Tests ]]]
 
@@ -1133,5 +1133,5 @@ Testing 0 internal secrets:
 
 
 Input vcode 0x00000001, Output vcode 0x00000001, Result vcode 0x00000001
-Verification value is 0x00000001 - Testing took 594.176606 seconds
+Verification value is 0x00000001 - Testing took 799.788256 seconds
 -------------------------------------------------------------------------------

--- a/src/aes_hash.rs
+++ b/src/aes_hash.rs
@@ -96,8 +96,8 @@ impl AHasher {
     #[inline]
     #[cfg(feature = "specialize")]
     fn short_finish(&self) -> u64 {
-        let combined = aesdec(self.sum, self.enc);
-        let result: [u64; 2] = aesenc(combined, combined).convert();
+        let combined = aesenc(self.sum, self.enc);
+        let result: [u64; 2] = aesdec(combined, combined).convert();
         result[0]
     }
 }
@@ -208,9 +208,9 @@ impl Hasher for AHasher {
     }
     #[inline]
     fn finish(&self) -> u64 {
-        let combined = aesdec(self.sum, self.enc);
-        let result: [u64; 2] = aesenc(aesenc(combined, self.key), combined).convert();
-        result[1]
+        let combined = aesenc(self.sum, self.enc);
+        let result: [u64; 2] = aesdec(aesdec(combined, self.key), combined).convert();
+        result[0]
     }
 }
 
@@ -329,15 +329,15 @@ impl Hasher for AHasherStr {
     fn write(&mut self, bytes: &[u8]) {
         if bytes.len() > 8 {
             self.0.write(bytes);
-            self.0.enc = aesdec(self.0.sum, self.0.enc);
-            self.0.enc = aesenc(aesenc(self.0.enc, self.0.key), self.0.enc);
+            self.0.enc = aesenc(self.0.sum, self.0.enc);
+            self.0.enc = aesdec(aesdec(self.0.enc, self.0.key), self.0.enc);
         } else {
             add_in_length(&mut self.0.enc, bytes.len() as u64);
 
             let value = read_small(bytes).convert();
             self.0.sum = shuffle_and_add(self.0.sum, value);
-            self.0.enc = aesdec(self.0.sum, self.0.enc);
-            self.0.enc = aesenc(aesenc(self.0.enc, self.0.key), self.0.enc);
+            self.0.enc = aesenc(self.0.sum, self.0.enc);
+            self.0.enc = aesdec(aesdec(self.0.enc, self.0.key), self.0.enc);
         }
     }
 

--- a/src/aes_hash.rs
+++ b/src/aes_hash.rs
@@ -81,15 +81,15 @@ impl AHasher {
 
     #[inline(always)]
     fn hash_in(&mut self, new_value: u128) {
-        self.enc = aesenc(self.enc, new_value);
+        self.enc = aesdec(self.enc, new_value);
         self.sum = shuffle_and_add(self.sum, new_value);
     }
 
     #[inline(always)]
     fn hash_in_2(&mut self, v1: u128, v2: u128) {
-        self.enc = aesenc(self.enc, v1);
+        self.enc = aesdec(self.enc, v1);
         self.sum = shuffle_and_add(self.sum, v1);
-        self.enc = aesenc(self.enc, v2);
+        self.enc = aesdec(self.enc, v2);
         self.sum = shuffle_and_add(self.sum, v2);
     }
 
@@ -174,10 +174,10 @@ impl Hasher for AHasher {
                     sum[1] = shuffle_and_add(sum[1], tail[3]);
                     while data.len() > 64 {
                         let (blocks, rest) = data.read_u128x4();
-                        current[0] = aesenc(current[0], blocks[0]);
-                        current[1] = aesenc(current[1], blocks[1]);
-                        current[2] = aesenc(current[2], blocks[2]);
-                        current[3] = aesenc(current[3], blocks[3]);
+                        current[0] = aesdec(current[0], blocks[0]);
+                        current[1] = aesdec(current[1], blocks[1]);
+                        current[2] = aesdec(current[2], blocks[2]);
+                        current[3] = aesdec(current[3], blocks[3]);
                         sum[0] = shuffle_and_add(sum[0], blocks[0]);
                         sum[1] = shuffle_and_add(sum[1], blocks[1]);
                         sum[0] = shuffle_and_add(sum[0], blocks[2]);


### PR DESCRIPTION
Because the AES decrypt and encrypt operations are symmetric, it seems like it should not matter which is used. However in the context of thinking about how one could theoretically extend attacks like #163 to be more general, there is a critical difference. If one attempts to cancel a differential after an AES round, it changes the canceling change from being all in one word vs one byte in each of 4 words. This matters in terms of how it interacts with the addition on the other half of the state. The spread out update is harder for an attacker to control and subsequently cancel, both because of carries and because it means operating on both 64byte halves of the added state at the same time.