### PR TITLE
Strengthen fastpath (#169)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ahash"
-version = "0.7.6"
+version = "0.7.7"
 authors = ["Tom Kaitchuck <Tom.Kaitchuck@gmail.com>"]
 license = "MIT OR Apache-2.0"
 description = "A non-cryptographic hash function using AES-NI for high performance"

--- a/smhasher/ahashOutput.txt
+++ b/smhasher/ahashOutput.txt
@@ -3,252 +3,196 @@
 
 [[[ Sanity Tests ]]]
 
-Verification value 0xE2190FCA ....... SKIP (self- or unseeded)
+Verification value 0x74CCCAD5 ....... SKIP (self- or unseeded)
 Running sanity check 1     .......... PASS
 Running AppendedZeroesTest .......... PASS
 
 [[[ Speed Tests ]]]
 
 Bulk speed test - 262144-byte keys
-Alignment  7 - 19.377 bytes/cycle - 55438.91 MiB/sec @ 3 ghz
-Alignment  6 - 19.474 bytes/cycle - 55716.64 MiB/sec @ 3 ghz
-Alignment  5 - 19.361 bytes/cycle - 55392.61 MiB/sec @ 3 ghz
-Alignment  4 - 19.471 bytes/cycle - 55708.26 MiB/sec @ 3 ghz
-Alignment  3 - 19.363 bytes/cycle - 55399.03 MiB/sec @ 3 ghz
-Alignment  2 - 19.312 bytes/cycle - 55252.57 MiB/sec @ 3 ghz
-Alignment  1 - 19.248 bytes/cycle - 55068.56 MiB/sec @ 3 ghz
-Alignment  0 - 20.429 bytes/cycle - 58448.42 MiB/sec @ 3 ghz
-Average      - 19.505 bytes/cycle - 55803.12 MiB/sec @ 3 ghz
+Alignment  7 - 21.075 bytes/cycle - 60295.19 MiB/sec @ 3 ghz
+Alignment  6 - 20.741 bytes/cycle - 59341.51 MiB/sec @ 3 ghz
+Alignment  5 - 20.881 bytes/cycle - 59741.43 MiB/sec @ 3 ghz
+Alignment  4 - 21.013 bytes/cycle - 60117.99 MiB/sec @ 3 ghz
+Alignment  3 - 20.976 bytes/cycle - 60012.54 MiB/sec @ 3 ghz
+Alignment  2 - 20.998 bytes/cycle - 60074.72 MiB/sec @ 3 ghz
+Alignment  1 - 21.026 bytes/cycle - 60154.64 MiB/sec @ 3 ghz
+Alignment  0 - 22.039 bytes/cycle - 63054.96 MiB/sec @ 3 ghz
+Average      - 21.094 bytes/cycle - 60349.12 MiB/sec @ 3 ghz
 
-Small key speed test -    1-byte keys -    17.84 cycles/hash
-Small key speed test -    2-byte keys -    17.90 cycles/hash
-Small key speed test -    3-byte keys -    17.91 cycles/hash
-Small key speed test -    4-byte keys -    17.96 cycles/hash
+Small key speed test -    1-byte keys -    18.00 cycles/hash
+Small key speed test -    2-byte keys -    18.00 cycles/hash
+Small key speed test -    3-byte keys -    18.00 cycles/hash
+Small key speed test -    4-byte keys -    18.00 cycles/hash
 Small key speed test -    5-byte keys -    18.00 cycles/hash
 Small key speed test -    6-byte keys -    18.00 cycles/hash
 Small key speed test -    7-byte keys -    18.00 cycles/hash
 Small key speed test -    8-byte keys -    18.00 cycles/hash
-Small key speed test -    9-byte keys -    17.13 cycles/hash
-Small key speed test -   10-byte keys -    18.30 cycles/hash
-Small key speed test -   11-byte keys -    18.28 cycles/hash
+Small key speed test -    9-byte keys -    18.00 cycles/hash
+Small key speed test -   10-byte keys -    18.19 cycles/hash
+Small key speed test -   11-byte keys -    18.00 cycles/hash
 Small key speed test -   12-byte keys -    18.00 cycles/hash
-Small key speed test -   13-byte keys -    18.00 cycles/hash
-Small key speed test -   14-byte keys -    18.31 cycles/hash
-Small key speed test -   15-byte keys -    18.00 cycles/hash
-Small key speed test -   16-byte keys -    18.27 cycles/hash
-Small key speed test -   17-byte keys -    20.16 cycles/hash
-Small key speed test -   18-byte keys -    19.70 cycles/hash
-Small key speed test -   19-byte keys -    19.83 cycles/hash
-Small key speed test -   20-byte keys -    19.60 cycles/hash
-Small key speed test -   21-byte keys -    19.97 cycles/hash
-Small key speed test -   22-byte keys -    19.71 cycles/hash
-Small key speed test -   23-byte keys -    19.59 cycles/hash
-Small key speed test -   24-byte keys -    19.84 cycles/hash
-Small key speed test -   25-byte keys -    19.92 cycles/hash
-Small key speed test -   26-byte keys -    19.80 cycles/hash
-Small key speed test -   27-byte keys -    19.84 cycles/hash
-Small key speed test -   28-byte keys -    19.60 cycles/hash
-Small key speed test -   29-byte keys -    20.52 cycles/hash
-Small key speed test -   30-byte keys -    20.44 cycles/hash
-Small key speed test -   31-byte keys -    20.41 cycles/hash
-Average                                    18.931 cycles/hash
+Small key speed test -   13-byte keys -    19.00 cycles/hash
+Small key speed test -   14-byte keys -    18.97 cycles/hash
+Small key speed test -   15-byte keys -    18.73 cycles/hash
+Small key speed test -   16-byte keys -    19.41 cycles/hash
+Small key speed test -   17-byte keys -    20.00 cycles/hash
+Small key speed test -   18-byte keys -    20.00 cycles/hash
+Small key speed test -   19-byte keys -    20.00 cycles/hash
+Small key speed test -   20-byte keys -    20.41 cycles/hash
+Small key speed test -   21-byte keys -    20.00 cycles/hash
+Small key speed test -   22-byte keys -    20.00 cycles/hash
+Small key speed test -   23-byte keys -    20.00 cycles/hash
+Small key speed test -   24-byte keys -    20.59 cycles/hash
+Small key speed test -   25-byte keys -    20.12 cycles/hash
+Small key speed test -   26-byte keys -    20.16 cycles/hash
+Small key speed test -   27-byte keys -    20.00 cycles/hash
+Small key speed test -   28-byte keys -    20.00 cycles/hash
+Small key speed test -   29-byte keys -    20.31 cycles/hash
+Small key speed test -   30-byte keys -    20.33 cycles/hash
+Small key speed test -   31-byte keys -    20.15 cycles/hash
+Average                                    19.173 cycles/hash
 
 [[[ 'Hashmap' Speed Tests ]]]
 
 std::unordered_map
-Init std HashMapTest:     453.695 cycles/op (102401 inserts, 1% deletions)
-Running std HashMapTest:  123.393 cycles/op (2.0 stdv)
+Init std HashMapTest:     186.422 cycles/op (104334 inserts, 1% deletions)
+Running std HashMapTest:  120.371 cycles/op (5.2 stdv)
 
 greg7mdp/parallel-hashmap
-Init fast HashMapTest:    113.578 cycles/op (102401 inserts, 1% deletions)
-Running fast HashMapTest: 88.084 cycles/op (2.6 stdv)  ....... PASS
+Init fast HashMapTest:    110.249 cycles/op (104334 inserts, 1% deletions)
+Running fast HashMapTest: 86.785 cycles/op (3.2 stdv)  ....... PASS
 
 [[[ Avalanche Tests ]]]
 
-Testing   24-bit keys ->  64-bit hashes, 300000 reps worst bias is 0.624667%
-Testing   32-bit keys ->  64-bit hashes, 300000 reps worst bias is 0.657333%
-Testing   40-bit keys ->  64-bit hashes, 300000 reps worst bias is 0.692000%
-Testing   48-bit keys ->  64-bit hashes, 300000 reps worst bias is 0.612667%
-Testing   56-bit keys ->  64-bit hashes, 300000 reps worst bias is 0.746000%
-Testing   64-bit keys ->  64-bit hashes, 300000 reps worst bias is 0.652000%
-Testing   72-bit keys ->  64-bit hashes, 300000 reps worst bias is 0.726667%
-Testing   80-bit keys ->  64-bit hashes, 300000 reps worst bias is 0.718667%
-Testing   96-bit keys ->  64-bit hashes, 300000 reps worst bias is 0.710667%
-Testing  112-bit keys ->  64-bit hashes, 300000 reps worst bias is 0.785333%
-Testing  128-bit keys ->  64-bit hashes, 300000 reps worst bias is 0.679333%
-Testing  160-bit keys ->  64-bit hashes, 300000 reps worst bias is 0.853333%
-Testing  512-bit keys ->  64-bit hashes, 300000 reps worst bias is 0.747333%
-Testing 1024-bit keys ->  64-bit hashes, 300000 reps worst bias is 0.807333%
+Testing   24-bit keys ->  64-bit hashes, 300000 reps.......... worst bias is 0.634667%
+Testing   32-bit keys ->  64-bit hashes, 300000 reps.......... worst bias is 0.600667%
+Testing   40-bit keys ->  64-bit hashes, 300000 reps.......... worst bias is 0.627333%
+Testing   48-bit keys ->  64-bit hashes, 300000 reps.......... worst bias is 0.656667%
+Testing   56-bit keys ->  64-bit hashes, 300000 reps.......... worst bias is 0.599333%
+Testing   64-bit keys ->  64-bit hashes, 300000 reps.......... worst bias is 0.690667%
+Testing   72-bit keys ->  64-bit hashes, 300000 reps.......... worst bias is 0.812667%
+Testing   80-bit keys ->  64-bit hashes, 300000 reps.......... worst bias is 0.678000%
+Testing   96-bit keys ->  64-bit hashes, 300000 reps.......... worst bias is 0.670000%
+Testing  112-bit keys ->  64-bit hashes, 300000 reps.......... worst bias is 0.728667%
+Testing  128-bit keys ->  64-bit hashes, 300000 reps.......... worst bias is 0.717333%
+Testing  160-bit keys ->  64-bit hashes, 300000 reps.......... worst bias is 0.681333%
+Testing  512-bit keys ->  64-bit hashes, 300000 reps.......... worst bias is 0.922000%
+Testing 1024-bit keys ->  64-bit hashes, 300000 reps.......... worst bias is 0.740000%
 
 [[[ Keyset 'Sparse' Tests ]]]
 
 Keyset 'Sparse' - 16-bit keys with up to 9 bits set - 50643 keys
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
 Testing collisions (high 32-bit) - Expected          0.3, actual      0 (0.00x)
-Testing collisions (high 19-25 bits) - Worst is 19 bits: 2365/2445 (0.97x)
-Testing collisions (high 12-bit) - Expected      46547.0, actual  46547 (1.00x)
-Testing collisions (high  8-bit) - Expected      50387.0, actual  50387 (1.00x)
+Testing collisions (high 19-25 bits) - Worst is 19 bits: 2369/2368 (1.00x)
 Testing collisions (low  32-bit) - Expected          0.3, actual      1 (3.35x) (1) !
-Testing collisions (low  19-25 bits) - Worst is 25 bits: 44/38 (1.15x)
-Testing collisions (low  12-bit) - Expected      46547.0, actual  46547 (1.00x)
-Testing collisions (low   8-bit) - Expected      50387.0, actual  50387 (1.00x)
-Testing distribution - Worst bias is the 13-bit window at bit 62 - 0.529%
+Testing collisions (low  19-25 bits) - Worst is 25 bits: 46/38 (1.20x)
+Testing distribution - Worst bias is the 13-bit window at bit 24 - 0.505%
 
 Keyset 'Sparse' - 24-bit keys with up to 8 bits set - 1271626 keys
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected        188.2, actual    209 (1.11x) (21)
-Testing collisions (high 24-35 bits) - Worst is 33 bits: 114/94 (1.21x)
-Testing collisions (high 12-bit) - Expected    1267530.0, actual 1267530 (1.00x)
-Testing collisions (high  8-bit) - Expected    1271370.0, actual 1271370 (1.00x)
-Testing collisions (low  32-bit) - Expected        188.2, actual    204 (1.08x) (16)
-Testing collisions (low  24-35 bits) - Worst is 33 bits: 103/94 (1.09x)
-Testing collisions (low  12-bit) - Expected    1267530.0, actual 1267530 (1.00x)
-Testing collisions (low   8-bit) - Expected    1271370.0, actual 1271370 (1.00x)
-Testing distribution - Worst bias is the 17-bit window at bit  2 - 0.101%
+Testing collisions (high 32-bit) - Expected        188.2, actual    171 (0.91x)
+Testing collisions (high 24-35 bits) - Worst is 28 bits: 3050/3007 (1.01x)
+Testing collisions (low  32-bit) - Expected        188.2, actual    193 (1.03x) (5)
+Testing collisions (low  24-35 bits) - Worst is 30 bits: 774/752 (1.03x)
+Testing distribution - Worst bias is the 17-bit window at bit 51 - 0.087%
 
 Keyset 'Sparse' - 32-bit keys with up to 7 bits set - 4514873 keys
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected       2373.0, actual   2435 (1.03x) (62)
-Testing collisions (high 25-38 bits) - Worst is 35 bits: 321/296 (1.08x)
-Testing collisions (high 12-bit) - Expected    4510777.0, actual 4510777 (1.00x)
-Testing collisions (high  8-bit) - Expected    4514617.0, actual 4514617 (1.00x)
-Testing collisions (low  32-bit) - Expected       2373.0, actual   2358 (0.99x) (-15)
-Testing collisions (low  25-38 bits) - Worst is 36 bits: 177/148 (1.19x)
-Testing collisions (low  12-bit) - Expected    4510777.0, actual 4510777 (1.00x)
-Testing collisions (low   8-bit) - Expected    4514617.0, actual 4514617 (1.00x)
-Testing distribution - Worst bias is the 19-bit window at bit 11 - 0.051%
+Testing collisions (high 32-bit) - Expected       2372.2, actual   2423 (1.02x) (51)
+Testing collisions (high 25-38 bits) - Worst is 36 bits: 162/148 (1.09x)
+Testing collisions (low  32-bit) - Expected       2372.2, actual   2312 (0.97x)
+Testing collisions (low  25-38 bits) - Worst is 38 bits: 42/37 (1.13x)
+Testing distribution - Worst bias is the 19-bit window at bit 19 - 0.040%
 
 Keyset 'Sparse' - 40-bit keys with up to 6 bits set - 4598479 keys
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected       2461.7, actual   2435 (0.99x) (-26)
-Testing collisions (high 25-38 bits) - Worst is 37 bits: 87/76 (1.13x)
-Testing collisions (high 12-bit) - Expected    4594383.0, actual 4594383 (1.00x)
-Testing collisions (high  8-bit) - Expected    4598223.0, actual 4598223 (1.00x)
-Testing collisions (low  32-bit) - Expected       2461.7, actual   2503 (1.02x) (42)
+Testing collisions (high 32-bit) - Expected       2460.8, actual   2483 (1.01x) (23)
+Testing collisions (high 25-38 bits) - Worst is 38 bits: 54/38 (1.40x)
+Testing collisions (low  32-bit) - Expected       2460.8, actual   2444 (0.99x) (-16)
 Testing collisions (low  25-38 bits) - Worst is 38 bits: 43/38 (1.12x)
-Testing collisions (low  12-bit) - Expected    4594383.0, actual 4594383 (1.00x)
-Testing collisions (low   8-bit) - Expected    4598223.0, actual 4598223 (1.00x)
-Testing distribution - Worst bias is the 18-bit window at bit 15 - 0.042%
+Testing distribution - Worst bias is the 19-bit window at bit 56 - 0.074%
 
 Keyset 'Sparse' - 48-bit keys with up to 6 bits set - 14196869 keys
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected      23463.6, actual  23382 (1.00x) (-81)
-Testing collisions (high 27-42 bits) - Worst is 42 bits: 29/22 (1.27x)
-Testing collisions (high 12-bit) - Expected   14192773.0, actual 14192773 (1.00x)
-Testing collisions (high  8-bit) - Expected   14196613.0, actual 14196613 (1.00x)
-Testing collisions (low  32-bit) - Expected      23463.6, actual  23449 (1.00x) (-14)
-Testing collisions (low  27-42 bits) - Worst is 42 bits: 29/22 (1.27x)
-Testing collisions (low  12-bit) - Expected   14192773.0, actual 14192773 (1.00x)
-Testing collisions (low   8-bit) - Expected   14196613.0, actual 14196613 (1.00x)
-Testing distribution - Worst bias is the 20-bit window at bit  2 - 0.020%
+Testing collisions (high 32-bit) - Expected      23437.8, actual  23188 (0.99x) (-249)
+Testing collisions (high 27-42 bits) - Worst is 30 bits: 93748/93442 (1.00x)
+Testing collisions (low  32-bit) - Expected      23437.8, actual  23337 (1.00x) (-100)
+Testing collisions (low  27-42 bits) - Worst is 39 bits: 187/183 (1.02x)
+Testing distribution - Worst bias is the 20-bit window at bit 30 - 0.021%
 
 Keyset 'Sparse' - 56-bit keys with up to 5 bits set - 4216423 keys
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected       2069.7, actual   2004 (0.97x)
-Testing collisions (high 25-38 bits) - Worst is 30 bits: 8414/8278 (1.02x)
-Testing collisions (high 12-bit) - Expected    4212327.0, actual 4212327 (1.00x)
-Testing collisions (high  8-bit) - Expected    4216167.0, actual 4216167 (1.00x)
-Testing collisions (low  32-bit) - Expected       2069.7, actual   2045 (0.99x) (-24)
-Testing collisions (low  25-38 bits) - Worst is 38 bits: 37/32 (1.14x)
-Testing collisions (low  12-bit) - Expected    4212327.0, actual 4212327 (1.00x)
-Testing collisions (low   8-bit) - Expected    4216167.0, actual 4216167 (1.00x)
-Testing distribution - Worst bias is the 19-bit window at bit  9 - 0.053%
+Testing collisions (high 32-bit) - Expected       2069.0, actual   2107 (1.02x) (39)
+Testing collisions (high 25-38 bits) - Worst is 36 bits: 147/129 (1.14x)
+Testing collisions (low  32-bit) - Expected       2069.0, actual   2111 (1.02x) (43)
+Testing collisions (low  25-38 bits) - Worst is 32 bits: 2111/2068 (1.02x)
+Testing distribution - Worst bias is the 18-bit window at bit 57 - 0.046%
 
 Keyset 'Sparse' - 64-bit keys with up to 5 bits set - 8303633 keys
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected       8026.9, actual   8097 (1.01x) (71)
-Testing collisions (high 26-40 bits) - Worst is 40 bits: 39/31 (1.24x)
-Testing collisions (high 12-bit) - Expected    8299537.0, actual 8299537 (1.00x)
-Testing collisions (high  8-bit) - Expected    8303377.0, actual 8303377 (1.00x)
-Testing collisions (low  32-bit) - Expected       8026.9, actual   7983 (0.99x) (-43)
-Testing collisions (low  26-40 bits) - Worst is 40 bits: 39/31 (1.24x)
-Testing collisions (low  12-bit) - Expected    8299537.0, actual 8299537 (1.00x)
-Testing collisions (low   8-bit) - Expected    8303377.0, actual 8303377 (1.00x)
-Testing distribution - Worst bias is the 20-bit window at bit 27 - 0.031%
+Testing collisions (high 32-bit) - Expected       8021.7, actual   7994 (1.00x) (-27)
+Testing collisions (high 26-40 bits) - Worst is 39 bits: 70/62 (1.12x)
+Testing collisions (low  32-bit) - Expected       8021.7, actual   8171 (1.02x) (150)
+Testing collisions (low  26-40 bits) - Worst is 39 bits: 66/62 (1.05x)
+Testing distribution - Worst bias is the 20-bit window at bit 32 - 0.044%
 
 Keyset 'Sparse' - 72-bit keys with up to 5 bits set - 15082603 keys
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected      26482.7, actual  26599 (1.00x) (117)
-Testing collisions (high 27-42 bits) - Worst is 40 bits: 108/103 (1.04x)
-Testing collisions (high 12-bit) - Expected   15078507.0, actual 15078507 (1.00x)
-Testing collisions (high  8-bit) - Expected   15082347.0, actual 15082347 (1.00x)
-Testing collisions (low  32-bit) - Expected      26482.7, actual  26491 (1.00x) (9)
-Testing collisions (low  27-42 bits) - Worst is 42 bits: 29/25 (1.12x)
-Testing collisions (low  12-bit) - Expected   15078507.0, actual 15078507 (1.00x)
-Testing collisions (low   8-bit) - Expected   15082347.0, actual 15082347 (1.00x)
-Testing distribution - Worst bias is the 20-bit window at bit 18 - 0.020%
+Testing collisions (high 32-bit) - Expected      26451.8, actual  26737 (1.01x) (286)
+Testing collisions (high 27-42 bits) - Worst is 37 bits: 854/827 (1.03x)
+Testing collisions (low  32-bit) - Expected      26451.8, actual  26464 (1.00x) (13)
+Testing collisions (low  27-42 bits) - Worst is 40 bits: 123/103 (1.19x)
+Testing distribution - Worst bias is the 20-bit window at bit 26 - 0.018%
 
 Keyset 'Sparse' - 96-bit keys with up to 4 bits set - 3469497 keys
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected       1401.3, actual   1380 (0.98x) (-21)
-Testing collisions (high 25-38 bits) - Worst is 31 bits: 2830/2802 (1.01x)
-Testing collisions (high 12-bit) - Expected    3465401.0, actual 3465401 (1.00x)
-Testing collisions (high  8-bit) - Expected    3469241.0, actual 3469241 (1.00x)
-Testing collisions (low  32-bit) - Expected       1401.3, actual   1350 (0.96x)
-Testing collisions (low  25-38 bits) - Worst is 34 bits: 347/350 (0.99x)
-Testing collisions (low  12-bit) - Expected    3465401.0, actual 3465401 (1.00x)
-Testing collisions (low   8-bit) - Expected    3469241.0, actual 3469241 (1.00x)
-Testing distribution - Worst bias is the 19-bit window at bit 14 - 0.052%
+Testing collisions (high 32-bit) - Expected       1401.0, actual   1387 (0.99x) (-13)
+Testing collisions (high 25-38 bits) - Worst is 35 bits: 190/175 (1.08x)
+Testing collisions (low  32-bit) - Expected       1401.0, actual   1415 (1.01x) (15)
+Testing collisions (low  25-38 bits) - Worst is 38 bits: 33/21 (1.51x)
+Testing distribution - Worst bias is the 19-bit window at bit 22 - 0.072%
 
 Keyset 'Sparse' - 160-bit keys with up to 4 bits set - 26977161 keys
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected      84723.3, actual  84639 (1.00x) (-84)
-Testing collisions (high 28-44 bits) - Worst is 40 bits: 343/330 (1.04x)
-Testing collisions (high 12-bit) - Expected   26973065.0, actual 26973065 (1.00x)
-Testing collisions (high  8-bit) - Expected   26976905.0, actual 26976905 (1.00x)
-Testing collisions (low  32-bit) - Expected      84723.3, actual  84648 (1.00x) (-75)
+Testing collisions (high 32-bit) - Expected      84546.1, actual  84950 (1.00x) (404)
+Testing collisions (high 28-44 bits) - Worst is 44 bits: 28/20 (1.35x)
+Testing collisions (low  32-bit) - Expected      84546.1, actual  84446 (1.00x) (-100)
 Testing collisions (low  28-44 bits) - Worst is 41 bits: 174/165 (1.05x)
-Testing collisions (low  12-bit) - Expected   26973065.0, actual 26973065 (1.00x)
-Testing collisions (low   8-bit) - Expected   26976905.0, actual 26976905 (1.00x)
-Testing distribution - Worst bias is the 20-bit window at bit  5 - 0.012%
+Testing distribution - Worst bias is the 20-bit window at bit 40 - 0.011%
 
 Keyset 'Sparse' - 256-bit keys with up to 3 bits set - 2796417 keys
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected        910.4, actual    935 (1.03x) (25)
-Testing collisions (high 25-37 bits) - Worst is 34 bits: 234/227 (1.03x)
-Testing collisions (high 12-bit) - Expected    2792321.0, actual 2792321 (1.00x)
-Testing collisions (high  8-bit) - Expected    2796161.0, actual 2796161 (1.00x)
-Testing collisions (low  32-bit) - Expected        910.4, actual    872 (0.96x)
-Testing collisions (low  25-37 bits) - Worst is 31 bits: 1806/1820 (0.99x)
-Testing collisions (low  12-bit) - Expected    2792321.0, actual 2792321 (1.00x)
-Testing collisions (low   8-bit) - Expected    2796161.0, actual 2796161 (1.00x)
-Testing distribution - Worst bias is the 19-bit window at bit 23 - 0.110%
+Testing collisions (high 32-bit) - Expected        910.2, actual    973 (1.07x) (63)
+Testing collisions (high 25-37 bits) - Worst is 35 bits: 130/113 (1.14x)
+Testing collisions (low  32-bit) - Expected        910.2, actual    962 (1.06x) (52)
+Testing collisions (low  25-37 bits) - Worst is 36 bits: 68/56 (1.20x)
+Testing distribution - Worst bias is the 19-bit window at bit 27 - 0.108%
 
 Keyset 'Sparse' - 512-bit keys with up to 3 bits set - 22370049 keys
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected      58256.4, actual  57953 (0.99x) (-303)
-Testing collisions (high 28-43 bits) - Worst is 43 bits: 37/28 (1.30x)
-Testing collisions (high 12-bit) - Expected   22365953.0, actual 22365953 (1.00x)
-Testing collisions (high  8-bit) - Expected   22369793.0, actual 22369793 (1.00x)
-Testing collisions (low  32-bit) - Expected      58256.4, actual  57776 (0.99x) (-480)
-Testing collisions (low  28-43 bits) - Worst is 36 bits: 3638/3641 (1.00x)
-Testing collisions (low  12-bit) - Expected   22365953.0, actual 22365953 (1.00x)
-Testing collisions (low   8-bit) - Expected   22369793.0, actual 22369793 (1.00x)
-Testing distribution - Worst bias is the 20-bit window at bit 40 - 0.015%
+Testing collisions (high 32-bit) - Expected      58155.4, actual  58209 (1.00x) (54)
+Testing collisions (high 28-43 bits) - Worst is 33 bits: 29243/29102 (1.00x)
+Testing collisions (low  32-bit) - Expected      58155.4, actual  58026 (1.00x) (-129)
+Testing collisions (low  28-43 bits) - Worst is 43 bits: 33/28 (1.16x)
+Testing distribution - Worst bias is the 20-bit window at bit 54 - 0.011%
 
 Keyset 'Sparse' - 1024-bit keys with up to 2 bits set - 524801 keys
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected         32.1, actual     34 (1.06x) (2)
-Testing collisions (high 22-32 bits) - Worst is 27 bits: 1093/1026 (1.07x)
-Testing collisions (high 12-bit) - Expected     520705.0, actual 520705 (1.00x)
-Testing collisions (high  8-bit) - Expected     524545.0, actual 524545 (1.00x)
-Testing collisions (low  32-bit) - Expected         32.1, actual     29 (0.90x)
-Testing collisions (low  22-32 bits) - Worst is 26 bits: 2053/2052 (1.00x)
-Testing collisions (low  12-bit) - Expected     520705.0, actual 520705 (1.00x)
-Testing collisions (low   8-bit) - Expected     524545.0, actual 524545 (1.00x)
-Testing distribution - Worst bias is the 16-bit window at bit 12 - 0.112%
+Testing collisions (high 32-bit) - Expected         32.1, actual     31 (0.97x)
+Testing collisions (high 22-32 bits) - Worst is 28 bits: 569/512 (1.11x)
+Testing collisions (low  32-bit) - Expected         32.1, actual     24 (0.75x)
+Testing collisions (low  22-32 bits) - Worst is 29 bits: 285/256 (1.11x)
+Testing distribution - Worst bias is the 16-bit window at bit 32 - 0.224%
 
 Keyset 'Sparse' - 2048-bit keys with up to 2 bits set - 2098177 keys
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected        512.5, actual    526 (1.03x) (14)
-Testing collisions (high 24-36 bits) - Worst is 31 bits: 1079/1025 (1.05x)
-Testing collisions (high 12-bit) - Expected    2094081.0, actual 2094081 (1.00x)
-Testing collisions (high  8-bit) - Expected    2097921.0, actual 2097921 (1.00x)
-Testing collisions (low  32-bit) - Expected        512.5, actual    516 (1.01x) (4)
-Testing collisions (low  24-36 bits) - Worst is 36 bits: 35/32 (1.09x)
-Testing collisions (low  12-bit) - Expected    2094081.0, actual 2094081 (1.00x)
-Testing collisions (low   8-bit) - Expected    2097921.0, actual 2097921 (1.00x)
-Testing distribution - Worst bias is the 18-bit window at bit 56 - 0.077%
+Testing collisions (high 32-bit) - Expected        512.4, actual    506 (0.99x) (-6)
+Testing collisions (high 24-36 bits) - Worst is 34 bits: 144/128 (1.12x)
+Testing collisions (low  32-bit) - Expected        512.4, actual    510 (1.00x) (-2)
+Testing collisions (low  24-36 bits) - Worst is 28 bits: 8200/8178 (1.00x)
+Testing distribution - Worst bias is the 18-bit window at bit 49 - 0.101%
 
 
 [[[ Keyset 'Permutation' Tests ]]]
@@ -256,211 +200,151 @@ Testing distribution - Worst bias is the 18-bit window at bit 56 - 0.077%
 Combination Lowbits Tests:
 Keyset 'Combination' - up to 7 blocks from a set of 8 - 2396744 keys
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected        668.7, actual    670 (1.00x) (2)
-Testing collisions (high 25-37 bits) - Worst is 36 bits: 57/41 (1.36x)
-Testing collisions (high 12-bit) - Expected    2392648.0, actual 2392648 (1.00x)
-Testing collisions (high  8-bit) - Expected    2396488.0, actual 2396488 (1.00x)
-Testing collisions (low  32-bit) - Expected        668.7, actual    671 (1.00x) (3)
-Testing collisions (low  25-37 bits) - Worst is 36 bits: 47/41 (1.12x)
-Testing collisions (low  12-bit) - Expected    2392648.0, actual 2392648 (1.00x)
-Testing collisions (low   8-bit) - Expected    2396488.0, actual 2396488 (1.00x)
-Testing distribution - Worst bias is the 18-bit window at bit 38 - 0.045%
+Testing collisions (high 32-bit) - Expected        668.6, actual    661 (0.99x) (-7)
+Testing collisions (high 24-37 bits) - Worst is 28 bits: 10767/10667 (1.01x)
+Testing collisions (low  32-bit) - Expected        668.6, actual    756 (1.13x) (88)
+Testing collisions (low  24-37 bits) - Worst is 35 bits: 99/83 (1.18x)
+Testing distribution - Worst bias is the 18-bit window at bit 41 - 0.081%
 
 
 Combination Highbits Tests
 Keyset 'Combination' - up to 7 blocks from a set of 8 - 2396744 keys
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected        668.7, actual    675 (1.01x) (7)
-Testing collisions (high 25-37 bits) - Worst is 36 bits: 47/41 (1.12x)
-Testing collisions (high 12-bit) - Expected    2392648.0, actual 2392648 (1.00x)
-Testing collisions (high  8-bit) - Expected    2396488.0, actual 2396488 (1.00x)
-Testing collisions (low  32-bit) - Expected        668.7, actual    705 (1.05x) (37)
-Testing collisions (low  25-37 bits) - Worst is 36 bits: 56/41 (1.34x)
-Testing collisions (low  12-bit) - Expected    2392648.0, actual 2392648 (1.00x)
-Testing collisions (low   8-bit) - Expected    2396488.0, actual 2396488 (1.00x)
-Testing distribution - Worst bias is the 18-bit window at bit 36 - 0.076%
+Testing collisions (high 32-bit) - Expected        668.6, actual    672 (1.01x) (4)
+Testing collisions (high 24-37 bits) - Worst is 31 bits: 1379/1336 (1.03x)
+Testing collisions (low  32-bit) - Expected        668.6, actual    680 (1.02x) (12)
+Testing collisions (low  24-37 bits) - Worst is 31 bits: 1387/1336 (1.04x)
+Testing distribution - Worst bias is the 18-bit window at bit 26 - 0.054%
 
 
 Combination Hi-Lo Tests:
 Keyset 'Combination' - up to 6 blocks from a set of 15 - 12204240 keys
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected      17339.3, actual  17329 (1.00x) (-10)
-Testing collisions (high 27-41 bits) - Worst is 40 bits: 79/67 (1.17x)
-Testing collisions (high 12-bit) - Expected   12200144.0, actual 12200144 (1.00x)
-Testing collisions (high  8-bit) - Expected   12203984.0, actual 12203984 (1.00x)
-Testing collisions (low  32-bit) - Expected      17339.3, actual  17439 (1.01x) (100)
-Testing collisions (low  27-41 bits) - Worst is 41 bits: 38/33 (1.12x)
-Testing collisions (low  12-bit) - Expected   12200144.0, actual 12200144 (1.00x)
-Testing collisions (low   8-bit) - Expected   12203984.0, actual 12203984 (1.00x)
-Testing distribution - Worst bias is the 20-bit window at bit 42 - 0.032%
+Testing collisions (high 32-bit) - Expected      17322.9, actual  17435 (1.01x) (113)
+Testing collisions (high 27-41 bits) - Worst is 41 bits: 39/33 (1.15x)
+Testing collisions (low  32-bit) - Expected      17322.9, actual  17089 (0.99x) (-233)
+Testing collisions (low  27-41 bits) - Worst is 40 bits: 79/67 (1.17x)
+Testing distribution - Worst bias is the 20-bit window at bit 15 - 0.026%
 
 
 Combination 0x8000000 Tests:
 Keyset 'Combination' - up to 22 blocks from a set of 2 - 8388606 keys
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected       8192.0, actual   8212 (1.00x) (21)
-Testing collisions (high 26-40 bits) - Worst is 31 bits: 16527/16383 (1.01x)
-Testing collisions (high 12-bit) - Expected    8384510.0, actual 8384510 (1.00x)
-Testing collisions (high  8-bit) - Expected    8388350.0, actual 8388350 (1.00x)
-Testing collisions (low  32-bit) - Expected       8192.0, actual   8167 (1.00x) (-24)
-Testing collisions (low  26-40 bits) - Worst is 40 bits: 40/31 (1.25x)
-Testing collisions (low  12-bit) - Expected    8384510.0, actual 8384510 (1.00x)
-Testing collisions (low   8-bit) - Expected    8388350.0, actual 8388350 (1.00x)
-Testing distribution - Worst bias is the 20-bit window at bit 57 - 0.039%
+Testing collisions (high 32-bit) - Expected       8186.7, actual   8218 (1.00x) (32)
+Testing collisions (high 26-40 bits) - Worst is 40 bits: 40/31 (1.25x)
+Testing collisions (low  32-bit) - Expected       8186.7, actual   8210 (1.00x) (24)
+Testing collisions (low  26-40 bits) - Worst is 32 bits: 8210/8186 (1.00x)
+Testing distribution - Worst bias is the 20-bit window at bit 16 - 0.047%
 
 
 Combination 0x0000001 Tests:
 Keyset 'Combination' - up to 22 blocks from a set of 2 - 8388606 keys
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected       8192.0, actual   8330 (1.02x) (139)
-Testing collisions (high 26-40 bits) - Worst is 40 bits: 38/31 (1.19x)
-Testing collisions (high 12-bit) - Expected    8384510.0, actual 8384510 (1.00x)
-Testing collisions (high  8-bit) - Expected    8388350.0, actual 8388350 (1.00x)
-Testing collisions (low  32-bit) - Expected       8192.0, actual   8247 (1.01x) (56)
-Testing collisions (low  26-40 bits) - Worst is 40 bits: 37/31 (1.16x)
-Testing collisions (low  12-bit) - Expected    8384510.0, actual 8384510 (1.00x)
-Testing collisions (low   8-bit) - Expected    8388350.0, actual 8388350 (1.00x)
-Testing distribution - Worst bias is the 20-bit window at bit 31 - 0.037%
+Testing collisions (high 32-bit) - Expected       8186.7, actual   8118 (0.99x) (-68)
+Testing collisions (high 26-40 bits) - Worst is 26 bits: 503735/503108 (1.00x)
+Testing collisions (low  32-bit) - Expected       8186.7, actual   8308 (1.01x) (122)
+Testing collisions (low  26-40 bits) - Worst is 37 bits: 272/255 (1.06x)
+Testing distribution - Worst bias is the 20-bit window at bit 59 - 0.056%
 
 
 Combination 0x800000000000000 Tests:
 Keyset 'Combination' - up to 22 blocks from a set of 2 - 8388606 keys
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected       8192.0, actual   8173 (1.00x) (-18)
-Testing collisions (high 26-40 bits) - Worst is 36 bits: 527/511 (1.03x)
-Testing collisions (high 12-bit) - Expected    8384510.0, actual 8384510 (1.00x)
-Testing collisions (high  8-bit) - Expected    8388350.0, actual 8388350 (1.00x)
-Testing collisions (low  32-bit) - Expected       8192.0, actual   7959 (0.97x)
-Testing collisions (low  26-40 bits) - Worst is 36 bits: 510/511 (1.00x)
-Testing collisions (low  12-bit) - Expected    8384510.0, actual 8384510 (1.00x)
-Testing collisions (low   8-bit) - Expected    8388350.0, actual 8388350 (1.00x)
-Testing distribution - Worst bias is the 20-bit window at bit 56 - 0.038%
+Testing collisions (high 32-bit) - Expected       8186.7, actual   8204 (1.00x) (18)
+Testing collisions (high 26-40 bits) - Worst is 39 bits: 70/63 (1.09x)
+Testing collisions (low  32-bit) - Expected       8186.7, actual   8149 (1.00x) (-37)
+Testing collisions (low  26-40 bits) - Worst is 30 bits: 32824/32682 (1.00x)
+Testing distribution - Worst bias is the 20-bit window at bit 61 - 0.039%
 
 
 Combination 0x000000000000001 Tests:
 Keyset 'Combination' - up to 22 blocks from a set of 2 - 8388606 keys
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected       8192.0, actual   8131 (0.99x) (-60)
-Testing collisions (high 26-40 bits) - Worst is 30 bits: 32886/32767 (1.00x)
-Testing collisions (high 12-bit) - Expected    8384510.0, actual 8384510 (1.00x)
-Testing collisions (high  8-bit) - Expected    8388350.0, actual 8388350 (1.00x)
-Testing collisions (low  32-bit) - Expected       8192.0, actual   8199 (1.00x) (8)
-Testing collisions (low  26-40 bits) - Worst is 34 bits: 2085/2047 (1.02x)
-Testing collisions (low  12-bit) - Expected    8384510.0, actual 8384510 (1.00x)
-Testing collisions (low   8-bit) - Expected    8388350.0, actual 8388350 (1.00x)
-Testing distribution - Worst bias is the 20-bit window at bit 17 - 0.037%
+Testing collisions (high 32-bit) - Expected       8186.7, actual   8288 (1.01x) (102)
+Testing collisions (high 26-40 bits) - Worst is 31 bits: 16594/16362 (1.01x)
+Testing collisions (low  32-bit) - Expected       8186.7, actual   8159 (1.00x) (-27)
+Testing collisions (low  26-40 bits) - Worst is 34 bits: 2078/2047 (1.01x)
+Testing distribution - Worst bias is the 20-bit window at bit 33 - 0.030%
 
 
 Combination 16-bytes [0-1] Tests:
 Keyset 'Combination' - up to 22 blocks from a set of 2 - 8388606 keys
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected       8192.0, actual   8230 (1.00x) (39)
-Testing collisions (high 26-40 bits) - Worst is 36 bits: 559/511 (1.09x)
-Testing collisions (high 12-bit) - Expected    8384510.0, actual 8384510 (1.00x)
-Testing collisions (high  8-bit) - Expected    8388350.0, actual 8388350 (1.00x)
-Testing collisions (low  32-bit) - Expected       8192.0, actual   8238 (1.01x) (47)
-Testing collisions (low  26-40 bits) - Worst is 32 bits: 8238/8191 (1.01x)
-Testing collisions (low  12-bit) - Expected    8384510.0, actual 8384510 (1.00x)
-Testing collisions (low   8-bit) - Expected    8388350.0, actual 8388350 (1.00x)
-Testing distribution - Worst bias is the 20-bit window at bit  0 - 0.032%
+Testing collisions (high 32-bit) - Expected       8186.7, actual   8107 (0.99x) (-79)
+Testing collisions (high 26-40 bits) - Worst is 38 bits: 134/127 (1.05x)
+Testing collisions (low  32-bit) - Expected       8186.7, actual   8153 (1.00x) (-33)
+Testing collisions (low  26-40 bits) - Worst is 39 bits: 70/63 (1.09x)
+Testing distribution - Worst bias is the 20-bit window at bit 10 - 0.046%
 
 
 Combination 16-bytes [0-last] Tests:
 Keyset 'Combination' - up to 22 blocks from a set of 2 - 8388606 keys
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected       8192.0, actual   8053 (0.98x) (-138)
-Testing collisions (high 26-40 bits) - Worst is 29 bits: 65079/65535 (0.99x)
-Testing collisions (high 12-bit) - Expected    8384510.0, actual 8384510 (1.00x)
-Testing collisions (high  8-bit) - Expected    8388350.0, actual 8388350 (1.00x)
-Testing collisions (low  32-bit) - Expected       8192.0, actual   8319 (1.02x) (128)
-Testing collisions (low  26-40 bits) - Worst is 39 bits: 74/63 (1.16x)
-Testing collisions (low  12-bit) - Expected    8384510.0, actual 8384510 (1.00x)
-Testing collisions (low   8-bit) - Expected    8388350.0, actual 8388350 (1.00x)
-Testing distribution - Worst bias is the 20-bit window at bit 32 - 0.041%
+Testing collisions (high 32-bit) - Expected       8186.7, actual   8163 (1.00x) (-23)
+Testing collisions (high 26-40 bits) - Worst is 38 bits: 144/127 (1.13x)
+Testing collisions (low  32-bit) - Expected       8186.7, actual   8116 (0.99x) (-70)
+Testing collisions (low  26-40 bits) - Worst is 26 bits: 504097/503108 (1.00x)
+Testing distribution - Worst bias is the 20-bit window at bit 16 - 0.042%
 
 
 Combination 32-bytes [0-1] Tests:
 Keyset 'Combination' - up to 22 blocks from a set of 2 - 8388606 keys
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected       8192.0, actual   8260 (1.01x) (69)
-Testing collisions (high 26-40 bits) - Worst is 32 bits: 8260/8191 (1.01x)
-Testing collisions (high 12-bit) - Expected    8384510.0, actual 8384510 (1.00x)
-Testing collisions (high  8-bit) - Expected    8388350.0, actual 8388350 (1.00x)
-Testing collisions (low  32-bit) - Expected       8192.0, actual   8311 (1.01x) (120)
-Testing collisions (low  26-40 bits) - Worst is 36 bits: 530/511 (1.04x)
-Testing collisions (low  12-bit) - Expected    8384510.0, actual 8384510 (1.00x)
-Testing collisions (low   8-bit) - Expected    8388350.0, actual 8388350 (1.00x)
-Testing distribution - Worst bias is the 20-bit window at bit 19 - 0.026%
+Testing collisions (high 32-bit) - Expected       8186.7, actual   8390 (1.02x) (204)
+Testing collisions (high 26-40 bits) - Worst is 40 bits: 34/31 (1.06x)
+Testing collisions (low  32-bit) - Expected       8186.7, actual   8106 (0.99x) (-80)
+Testing collisions (low  26-40 bits) - Worst is 26 bits: 502218/503108 (1.00x)
+Testing distribution - Worst bias is the 20-bit window at bit  6 - 0.037%
 
 
 Combination 32-bytes [0-last] Tests:
 Keyset 'Combination' - up to 22 blocks from a set of 2 - 8388606 keys
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected       8192.0, actual   8250 (1.01x) (59)
-Testing collisions (high 26-40 bits) - Worst is 38 bits: 133/127 (1.04x)
-Testing collisions (high 12-bit) - Expected    8384510.0, actual 8384510 (1.00x)
-Testing collisions (high  8-bit) - Expected    8388350.0, actual 8388350 (1.00x)
-Testing collisions (low  32-bit) - Expected       8192.0, actual   8167 (1.00x) (-24)
-Testing collisions (low  26-40 bits) - Worst is 39 bits: 66/63 (1.03x)
-Testing collisions (low  12-bit) - Expected    8384510.0, actual 8384510 (1.00x)
-Testing collisions (low   8-bit) - Expected    8388350.0, actual 8388350 (1.00x)
-Testing distribution - Worst bias is the 20-bit window at bit 36 - 0.036%
+Testing collisions (high 32-bit) - Expected       8186.7, actual   8387 (1.02x) (201)
+Testing collisions (high 26-40 bits) - Worst is 38 bits: 144/127 (1.13x)
+Testing collisions (low  32-bit) - Expected       8186.7, actual   7860 (0.96x)
+Testing collisions (low  26-40 bits) - Worst is 26 bits: 503416/503108 (1.00x)
+Testing distribution - Worst bias is the 20-bit window at bit 22 - 0.030%
 
 
 Combination 64-bytes [0-1] Tests:
 Keyset 'Combination' - up to 22 blocks from a set of 2 - 8388606 keys
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected       8192.0, actual   8174 (1.00x) (-17)
-Testing collisions (high 26-40 bits) - Worst is 39 bits: 66/63 (1.03x)
-Testing collisions (high 12-bit) - Expected    8384510.0, actual 8384510 (1.00x)
-Testing collisions (high  8-bit) - Expected    8388350.0, actual 8388350 (1.00x)
-Testing collisions (low  32-bit) - Expected       8192.0, actual   8301 (1.01x) (110)
-Testing collisions (low  26-40 bits) - Worst is 37 bits: 272/255 (1.06x)
-Testing collisions (low  12-bit) - Expected    8384510.0, actual 8384510 (1.00x)
-Testing collisions (low   8-bit) - Expected    8388350.0, actual 8388350 (1.00x)
-Testing distribution - Worst bias is the 20-bit window at bit 17 - 0.043%
+Testing collisions (high 32-bit) - Expected       8186.7, actual   8126 (0.99x) (-60)
+Testing collisions (high 26-40 bits) - Worst is 38 bits: 148/127 (1.16x)
+Testing collisions (low  32-bit) - Expected       8186.7, actual   8171 (1.00x) (-15)
+Testing collisions (low  26-40 bits) - Worst is 36 bits: 523/511 (1.02x)
+Testing distribution - Worst bias is the 20-bit window at bit 40 - 0.042%
 
 
 Combination 64-bytes [0-last] Tests:
 Keyset 'Combination' - up to 22 blocks from a set of 2 - 8388606 keys
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected       8192.0, actual   8110 (0.99x) (-81)
-Testing collisions (high 26-40 bits) - Worst is 39 bits: 77/63 (1.20x)
-Testing collisions (high 12-bit) - Expected    8384510.0, actual 8384510 (1.00x)
-Testing collisions (high  8-bit) - Expected    8388350.0, actual 8388350 (1.00x)
-Testing collisions (low  32-bit) - Expected       8192.0, actual   8261 (1.01x) (70)
-Testing collisions (low  26-40 bits) - Worst is 32 bits: 8261/8191 (1.01x)
-Testing collisions (low  12-bit) - Expected    8384510.0, actual 8384510 (1.00x)
-Testing collisions (low   8-bit) - Expected    8388350.0, actual 8388350 (1.00x)
-Testing distribution - Worst bias is the 20-bit window at bit 26 - 0.043%
+Testing collisions (high 32-bit) - Expected       8186.7, actual   8289 (1.01x) (103)
+Testing collisions (high 26-40 bits) - Worst is 36 bits: 546/511 (1.07x)
+Testing collisions (low  32-bit) - Expected       8186.7, actual   8002 (0.98x)
+Testing collisions (low  26-40 bits) - Worst is 39 bits: 66/63 (1.03x)
+Testing distribution - Worst bias is the 20-bit window at bit  7 - 0.039%
 
 
 Combination 128-bytes [0-1] Tests:
 Keyset 'Combination' - up to 22 blocks from a set of 2 - 8388606 keys
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected       8192.0, actual   7947 (0.97x)
-Testing collisions (high 26-40 bits) - Worst is 35 bits: 1036/1023 (1.01x)
-Testing collisions (high 12-bit) - Expected    8384510.0, actual 8384510 (1.00x)
-Testing collisions (high  8-bit) - Expected    8388350.0, actual 8388350 (1.00x)
-Testing collisions (low  32-bit) - Expected       8192.0, actual   8127 (0.99x) (-64)
-Testing collisions (low  26-40 bits) - Worst is 39 bits: 79/63 (1.23x)
-Testing collisions (low  12-bit) - Expected    8384510.0, actual 8384510 (1.00x)
-Testing collisions (low   8-bit) - Expected    8388350.0, actual 8388350 (1.00x)
-Testing distribution - Worst bias is the 20-bit window at bit 17 - 0.030%
+Testing collisions (high 32-bit) - Expected       8186.7, actual   8099 (0.99x) (-87)
+Testing collisions (high 26-40 bits) - Worst is 40 bits: 38/31 (1.19x)
+Testing collisions (low  32-bit) - Expected       8186.7, actual   8269 (1.01x) (83)
+Testing collisions (low  26-40 bits) - Worst is 40 bits: 40/31 (1.25x)
+Testing distribution - Worst bias is the 20-bit window at bit 10 - 0.029%
 
 
 Combination 128-bytes [0-last] Tests:
 Keyset 'Combination' - up to 22 blocks from a set of 2 - 8388606 keys
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected       8192.0, actual   8309 (1.01x) (118)
-Testing collisions (high 26-40 bits) - Worst is 34 bits: 2086/2047 (1.02x)
-Testing collisions (high 12-bit) - Expected    8384510.0, actual 8384510 (1.00x)
-Testing collisions (high  8-bit) - Expected    8388350.0, actual 8388350 (1.00x)
-Testing collisions (low  32-bit) - Expected       8192.0, actual   8190 (1.00x) (-1)
-Testing collisions (low  26-40 bits) - Worst is 38 bits: 152/127 (1.19x)
-Testing collisions (low  12-bit) - Expected    8384510.0, actual 8384510 (1.00x)
-Testing collisions (low   8-bit) - Expected    8388350.0, actual 8388350 (1.00x)
-Testing distribution - Worst bias is the 20-bit window at bit 32 - 0.045%
+Testing collisions (high 32-bit) - Expected       8186.7, actual   8279 (1.01x) (93)
+Testing collisions (high 26-40 bits) - Worst is 40 bits: 39/31 (1.22x)
+Testing collisions (low  32-bit) - Expected       8186.7, actual   8252 (1.01x) (66)
+Testing collisions (low  26-40 bits) - Worst is 39 bits: 75/63 (1.17x)
+Testing distribution - Worst bias is the 20-bit window at bit  9 - 0.029%
 
 
 [[[ Keyset 'Window' Tests ]]]
@@ -504,257 +388,184 @@ Window at  32 - Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0
 
 Keyset 'Cyclic' - 8 cycles of 8 bytes - 1000000 keys
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected        116.4, actual    121 (1.04x) (5)
-Testing collisions (high 23-34 bits) - Worst is 33 bits: 63/58 (1.08x)
-Testing collisions (high 12-bit) - Expected     995904.0, actual 995904 (1.00x)
-Testing collisions (high  8-bit) - Expected     999744.0, actual 999744 (1.00x)
-Testing collisions (low  32-bit) - Expected        116.4, actual    124 (1.07x) (8)
-Testing collisions (low  23-34 bits) - Worst is 32 bits: 124/116 (1.07x)
-Testing collisions (low  12-bit) - Expected     995904.0, actual 995904 (1.00x)
-Testing collisions (low   8-bit) - Expected     999744.0, actual 999744 (1.00x)
-Testing distribution - Worst bias is the 17-bit window at bit 38 - 0.087%
+Testing collisions (high 32-bit) - Expected        116.4, actual    103 (0.88x)
+Testing collisions (high 23-34 bits) - Worst is 30 bits: 495/465 (1.06x)
+Testing collisions (low  32-bit) - Expected        116.4, actual    109 (0.94x)
+Testing collisions (low  23-34 bits) - Worst is 30 bits: 468/465 (1.01x)
+Testing distribution - Worst bias is the 17-bit window at bit 37 - 0.111%
 
 Keyset 'Cyclic' - 8 cycles of 9 bytes - 1000000 keys
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected        116.4, actual    127 (1.09x) (11)
-Testing collisions (high 23-34 bits) - Worst is 34 bits: 41/29 (1.41x)
-Testing collisions (high 12-bit) - Expected     995904.0, actual 995904 (1.00x)
-Testing collisions (high  8-bit) - Expected     999744.0, actual 999744 (1.00x)
-Testing collisions (low  32-bit) - Expected        116.4, actual    101 (0.87x)
-Testing collisions (low  23-34 bits) - Worst is 34 bits: 30/29 (1.03x)
-Testing collisions (low  12-bit) - Expected     995904.0, actual 995904 (1.00x)
-Testing collisions (low   8-bit) - Expected     999744.0, actual 999744 (1.00x)
-Testing distribution - Worst bias is the 17-bit window at bit 43 - 0.101%
+Testing collisions (high 32-bit) - Expected        116.4, actual    106 (0.91x)
+Testing collisions (high 23-34 bits) - Worst is 33 bits: 62/58 (1.07x)
+Testing collisions (low  32-bit) - Expected        116.4, actual    120 (1.03x) (4)
+Testing collisions (low  23-34 bits) - Worst is 34 bits: 46/29 (1.58x)
+Testing distribution - Worst bias is the 17-bit window at bit 48 - 0.132%
 
 Keyset 'Cyclic' - 8 cycles of 10 bytes - 1000000 keys
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected        116.4, actual    133 (1.14x) (17)
-Testing collisions (high 23-34 bits) - Worst is 34 bits: 39/29 (1.34x)
-Testing collisions (high 12-bit) - Expected     995904.0, actual 995904 (1.00x)
-Testing collisions (high  8-bit) - Expected     999744.0, actual 999744 (1.00x)
-Testing collisions (low  32-bit) - Expected        116.4, actual    119 (1.02x) (3)
-Testing collisions (low  23-34 bits) - Worst is 32 bits: 119/116 (1.02x)
-Testing collisions (low  12-bit) - Expected     995904.0, actual 995904 (1.00x)
-Testing collisions (low   8-bit) - Expected     999744.0, actual 999744 (1.00x)
-Testing distribution - Worst bias is the 17-bit window at bit  6 - 0.138%
+Testing collisions (high 32-bit) - Expected        116.4, actual    116 (1.00x)
+Testing collisions (high 23-34 bits) - Worst is 33 bits: 63/58 (1.08x)
+Testing collisions (low  32-bit) - Expected        116.4, actual    116 (1.00x)
+Testing collisions (low  23-34 bits) - Worst is 33 bits: 68/58 (1.17x)
+Testing distribution - Worst bias is the 17-bit window at bit 60 - 0.103%
 
 Keyset 'Cyclic' - 8 cycles of 11 bytes - 1000000 keys
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected        116.4, actual    131 (1.13x) (15)
-Testing collisions (high 23-34 bits) - Worst is 33 bits: 74/58 (1.27x)
-Testing collisions (high 12-bit) - Expected     995904.0, actual 995904 (1.00x)
-Testing collisions (high  8-bit) - Expected     999744.0, actual 999744 (1.00x)
-Testing collisions (low  32-bit) - Expected        116.4, actual    118 (1.01x) (2)
-Testing collisions (low  23-34 bits) - Worst is 34 bits: 39/29 (1.34x)
-Testing collisions (low  12-bit) - Expected     995904.0, actual 995904 (1.00x)
-Testing collisions (low   8-bit) - Expected     999744.0, actual 999744 (1.00x)
-Testing distribution - Worst bias is the 17-bit window at bit 43 - 0.115%
+Testing collisions (high 32-bit) - Expected        116.4, actual    129 (1.11x) (13)
+Testing collisions (high 23-34 bits) - Worst is 33 bits: 69/58 (1.19x)
+Testing collisions (low  32-bit) - Expected        116.4, actual    120 (1.03x) (4)
+Testing collisions (low  23-34 bits) - Worst is 32 bits: 120/116 (1.03x)
+Testing distribution - Worst bias is the 17-bit window at bit 27 - 0.109%
 
 Keyset 'Cyclic' - 8 cycles of 12 bytes - 1000000 keys
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected        116.4, actual    115 (0.99x) (-1)
-Testing collisions (high 23-34 bits) - Worst is 34 bits: 31/29 (1.07x)
-Testing collisions (high 12-bit) - Expected     995904.0, actual 995904 (1.00x)
-Testing collisions (high  8-bit) - Expected     999744.0, actual 999744 (1.00x)
-Testing collisions (low  32-bit) - Expected        116.4, actual    111 (0.95x)
-Testing collisions (low  23-34 bits) - Worst is 34 bits: 32/29 (1.10x)
-Testing collisions (low  12-bit) - Expected     995904.0, actual 995904 (1.00x)
-Testing collisions (low   8-bit) - Expected     999744.0, actual 999744 (1.00x)
-Testing distribution - Worst bias is the 16-bit window at bit 13 - 0.080%
+Testing collisions (high 32-bit) - Expected        116.4, actual     95 (0.82x)
+Testing collisions (high 23-34 bits) - Worst is 23 bits: 56886/57305 (0.99x)
+Testing collisions (low  32-bit) - Expected        116.4, actual    120 (1.03x) (4)
+Testing collisions (low  23-34 bits) - Worst is 34 bits: 34/29 (1.17x)
+Testing distribution - Worst bias is the 17-bit window at bit 46 - 0.134%
 
 Keyset 'Cyclic' - 8 cycles of 16 bytes - 1000000 keys
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected        116.4, actual    115 (0.99x) (-1)
-Testing collisions (high 23-34 bits) - Worst is 30 bits: 474/465 (1.02x)
-Testing collisions (high 12-bit) - Expected     995904.0, actual 995904 (1.00x)
-Testing collisions (high  8-bit) - Expected     999744.0, actual 999744 (1.00x)
-Testing collisions (low  32-bit) - Expected        116.4, actual    135 (1.16x) (19)
-Testing collisions (low  23-34 bits) - Worst is 34 bits: 37/29 (1.27x)
-Testing collisions (low  12-bit) - Expected     995904.0, actual 995904 (1.00x)
-Testing collisions (low   8-bit) - Expected     999744.0, actual 999744 (1.00x)
-Testing distribution - Worst bias is the 17-bit window at bit 62 - 0.119%
+Testing collisions (high 32-bit) - Expected        116.4, actual    126 (1.08x) (10)
+Testing collisions (high 23-34 bits) - Worst is 33 bits: 79/58 (1.36x)
+Testing collisions (low  32-bit) - Expected        116.4, actual     98 (0.84x)
+Testing collisions (low  23-34 bits) - Worst is 23 bits: 57131/57305 (1.00x)
+Testing distribution - Worst bias is the 17-bit window at bit 31 - 0.147%
 
 
 [[[ Keyset 'TwoBytes' Tests ]]]
 
 Keyset 'TwoBytes' - up-to-4-byte keys, 652545 total keys
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected         49.6, actual     52 (1.05x) (3)
-Testing collisions (high 23-33 bits) - Worst is 31 bits: 115/99 (1.16x)
-Testing collisions (high 12-bit) - Expected     648449.0, actual 648449 (1.00x)
-Testing collisions (high  8-bit) - Expected     652289.0, actual 652289 (1.00x)
-Testing collisions (low  32-bit) - Expected         49.6, actual     55 (1.11x) (6)
-Testing collisions (low  23-33 bits) - Worst is 32 bits: 55/49 (1.11x)
-Testing collisions (low  12-bit) - Expected     648449.0, actual 648449 (1.00x)
-Testing collisions (low   8-bit) - Expected     652289.0, actual 652289 (1.00x)
-Testing distribution - Worst bias is the 16-bit window at bit 61 - 0.110%
+Testing collisions (high 32-bit) - Expected         49.6, actual     42 (0.85x)
+Testing collisions (high 23-33 bits) - Worst is 24 bits: 12603/12527 (1.01x)
+Testing collisions (low  32-bit) - Expected         49.6, actual     44 (0.89x)
+Testing collisions (low  23-33 bits) - Worst is 27 bits: 1606/1583 (1.01x)
+Testing distribution - Worst bias is the 16-bit window at bit 36 - 0.093%
 
 Keyset 'TwoBytes' - up-to-8-byte keys, 5471025 total keys
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected       3484.6, actual   3705 (1.06x) (221)
-Testing collisions (high 26-39 bits) - Worst is 32 bits: 3705/3484 (1.06x)
-Testing collisions (high 12-bit) - Expected    5466929.0, actual 5466929 (1.00x)
-Testing collisions (high  8-bit) - Expected    5470769.0, actual 5470769 (1.00x)
-Testing collisions (low  32-bit) - Expected       3484.6, actual   3491 (1.00x) (7)
-Testing collisions (low  26-39 bits) - Worst is 38 bits: 63/54 (1.16x)
-Testing collisions (low  12-bit) - Expected    5466929.0, actual 5466929 (1.00x)
-Testing collisions (low   8-bit) - Expected    5470769.0, actual 5470769 (1.00x)
-Testing distribution - Worst bias is the 20-bit window at bit 17 - 0.060%
+Testing collisions (high 32-bit) - Expected       3483.1, actual   3401 (0.98x)
+Testing collisions (high 26-39 bits) - Worst is 37 bits: 111/108 (1.02x)
+Testing collisions (low  32-bit) - Expected       3483.1, actual   3448 (0.99x) (-35)
+Testing collisions (low  26-39 bits) - Worst is 37 bits: 121/108 (1.11x)
+Testing distribution - Worst bias is the 20-bit window at bit 57 - 0.040%
 
 Keyset 'TwoBytes' - up-to-12-byte keys, 18616785 total keys
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected      40347.8, actual  40284 (1.00x) (-63)
-Testing collisions (high 27-42 bits) - Worst is 41 bits: 83/78 (1.05x)
-Testing collisions (high 12-bit) - Expected   18612689.0, actual 18612689 (1.00x)
-Testing collisions (high  8-bit) - Expected   18616529.0, actual 18616529 (1.00x)
-Testing collisions (low  32-bit) - Expected      40347.8, actual  40406 (1.00x) (59)
-Testing collisions (low  27-42 bits) - Worst is 35 bits: 5078/5043 (1.01x)
-Testing collisions (low  12-bit) - Expected   18612689.0, actual 18612689 (1.00x)
-Testing collisions (low   8-bit) - Expected   18616529.0, actual 18616529 (1.00x)
-Testing distribution - Worst bias is the 20-bit window at bit 22 - 0.019%
+Testing collisions (high 32-bit) - Expected      40289.5, actual  39941 (0.99x) (-348)
+Testing collisions (high 27-42 bits) - Worst is 27 bits: 1233062/1233446 (1.00x)
+Testing collisions (low  32-bit) - Expected      40289.5, actual  40360 (1.00x) (71)
+Testing collisions (low  27-42 bits) - Worst is 37 bits: 1310/1260 (1.04x)
+Testing distribution - Worst bias is the 20-bit window at bit 62 - 0.019%
 
 Keyset 'TwoBytes' - up-to-16-byte keys, 44251425 total keys
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected     227963.2, actual 228535 (1.00x) (572)
-Testing collisions (high 29-45 bits) - Worst is 41 bits: 464/445 (1.04x)
-Testing collisions (high 12-bit) - Expected   44247329.0, actual 44247329 (1.00x)
-Testing collisions (high  8-bit) - Expected   44251169.0, actual 44251169 (1.00x)
-Testing collisions (low  32-bit) - Expected     227963.2, actual 227324 (1.00x) (-639)
-Testing collisions (low  29-45 bits) - Worst is 44 bits: 61/55 (1.10x)
-Testing collisions (low  12-bit) - Expected   44247329.0, actual 44247329 (1.00x)
-Testing collisions (low   8-bit) - Expected   44251169.0, actual 44251169 (1.00x)
-Testing distribution - Worst bias is the 20-bit window at bit 22 - 0.012%
+Testing collisions (high 32-bit) - Expected     227182.3, actual 227244 (1.00x) (62)
+Testing collisions (high 29-45 bits) - Worst is 44 bits: 60/55 (1.08x)
+Testing collisions (low  32-bit) - Expected     227182.3, actual 227447 (1.00x) (265)
+Testing collisions (low  29-45 bits) - Worst is 37 bits: 7356/7123 (1.03x)
+Testing distribution - Worst bias is the 19-bit window at bit  1 - 0.004%
 
 Keyset 'TwoBytes' - up-to-20-byte keys, 86536545 total keys
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected     871784.7, actual 866964 (0.99x) (-4820)
-Testing collisions (high 30-47 bits) - Worst is 42 bits: 893/851 (1.05x)
-Testing collisions (high 12-bit) - Expected   86532449.0, actual 86532449 (1.00x)
-Testing collisions (high  8-bit) - Expected   86536289.0, actual 86536289 (1.00x)
-Testing collisions (low  32-bit) - Expected     871784.7, actual 866400 (0.99x) (-5384)
-Testing collisions (low  30-47 bits) - Worst is 33 bits: 434401/435892 (1.00x)
-Testing collisions (low  12-bit) - Expected   86532449.0, actual 86532449 (1.00x)
-Testing collisions (low   8-bit) - Expected   86536289.0, actual 86536289 (1.00x)
-Testing distribution - Worst bias is the 20-bit window at bit 59 - 0.004%
+Testing collisions (high 32-bit) - Expected     865959.1, actual 866640 (1.00x) (681)
+Testing collisions (high 30-47 bits) - Worst is 44 bits: 230/212 (1.08x)
+Testing collisions (low  32-bit) - Expected     865959.1, actual 866255 (1.00x) (296)
+Testing collisions (low  30-47 bits) - Worst is 38 bits: 13774/13620 (1.01x)
+Testing distribution - Worst bias is the 20-bit window at bit 50 - 0.005%
 
 
 [[[ Keyset 'Text' Tests ]]]
 
 Keyset 'Text' - keys of form "FooXXXXBar" - 14776336 keys
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected      25418.1, actual  25470 (1.00x) (52)
-Testing collisions (high 27-42 bits) - Worst is 39 bits: 204/198 (1.03x)
-Testing collisions (high 12-bit) - Expected   14772240.0, actual 14772240 (1.00x)
-Testing collisions (high  8-bit) - Expected   14776080.0, actual 14776080 (1.00x)
-Testing collisions (low  32-bit) - Expected      25418.1, actual  25289 (0.99x) (-129)
-Testing collisions (low  27-42 bits) - Worst is 41 bits: 51/49 (1.03x)
-Testing collisions (low  12-bit) - Expected   14772240.0, actual 14772240 (1.00x)
-Testing collisions (low   8-bit) - Expected   14776080.0, actual 14776080 (1.00x)
-Testing distribution - Worst bias is the 20-bit window at bit 50 - 0.019%
+Testing collisions (high 32-bit) - Expected      25389.0, actual  25650 (1.01x) (261)
+Testing collisions (high 27-42 bits) - Worst is 39 bits: 208/198 (1.05x)
+Testing collisions (low  32-bit) - Expected      25389.0, actual  25416 (1.00x) (27)
+Testing collisions (low  27-42 bits) - Worst is 36 bits: 1653/1588 (1.04x)
+Testing distribution - Worst bias is the 20-bit window at bit  7 - 0.019%
 
 Keyset 'Text' - keys of form "FooBarXXXX" - 14776336 keys
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected      25418.1, actual  25311 (1.00x) (-107)
-Testing collisions (high 27-42 bits) - Worst is 42 bits: 30/24 (1.21x)
-Testing collisions (high 12-bit) - Expected   14772240.0, actual 14772240 (1.00x)
-Testing collisions (high  8-bit) - Expected   14776080.0, actual 14776080 (1.00x)
-Testing collisions (low  32-bit) - Expected      25418.1, actual  25475 (1.00x) (57)
+Testing collisions (high 32-bit) - Expected      25389.0, actual  25488 (1.00x) (99)
+Testing collisions (high 27-42 bits) - Worst is 40 bits: 106/99 (1.07x)
+Testing collisions (low  32-bit) - Expected      25389.0, actual  25444 (1.00x) (55)
 Testing collisions (low  27-42 bits) - Worst is 42 bits: 27/24 (1.09x)
-Testing collisions (low  12-bit) - Expected   14772240.0, actual 14772240 (1.00x)
-Testing collisions (low   8-bit) - Expected   14776080.0, actual 14776080 (1.00x)
-Testing distribution - Worst bias is the 20-bit window at bit 45 - 0.023%
+Testing distribution - Worst bias is the 19-bit window at bit 58 - 0.011%
 
 Keyset 'Text' - keys of form "XXXXFooBar" - 14776336 keys
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected      25418.1, actual  25622 (1.01x) (204)
-Testing collisions (high 27-42 bits) - Worst is 42 bits: 29/24 (1.17x)
-Testing collisions (high 12-bit) - Expected   14772240.0, actual 14772240 (1.00x)
-Testing collisions (high  8-bit) - Expected   14776080.0, actual 14776080 (1.00x)
-Testing collisions (low  32-bit) - Expected      25418.1, actual  25007 (0.98x) (-411)
-Testing collisions (low  27-42 bits) - Worst is 42 bits: 29/24 (1.17x)
-Testing collisions (low  12-bit) - Expected   14772240.0, actual 14772240 (1.00x)
-Testing collisions (low   8-bit) - Expected   14776080.0, actual 14776080 (1.00x)
-Testing distribution - Worst bias is the 19-bit window at bit 53 - 0.026%
+Testing collisions (high 32-bit) - Expected      25389.0, actual  25061 (0.99x) (-328)
+Testing collisions (high 27-42 bits) - Worst is 41 bits: 58/49 (1.17x)
+Testing collisions (low  32-bit) - Expected      25389.0, actual  25212 (0.99x) (-177)
+Testing collisions (low  27-42 bits) - Worst is 37 bits: 799/794 (1.01x)
+Testing distribution - Worst bias is the 20-bit window at bit  6 - 0.024%
 
 Keyset 'Words' - 4000000 random keys of len 6-16 from alnum charset
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected       1862.6, actual   1833 (0.98x) (-29)
-Testing collisions (high 25-38 bits) - Worst is 33 bits: 940/931 (1.01x)
-Testing collisions (high 12-bit) - Expected    3995904.0, actual 3995904 (1.00x)
-Testing collisions (high  8-bit) - Expected    3999744.0, actual 3999744 (1.00x)
-Testing collisions (low  32-bit) - Expected       1862.6, actual   1873 (1.01x) (11)
-Testing collisions (low  25-38 bits) - Worst is 36 bits: 129/116 (1.11x)
-Testing collisions (low  12-bit) - Expected    3995904.0, actual 3995904 (1.00x)
-Testing collisions (low   8-bit) - Expected    3999744.0, actual 3999744 (1.00x)
-Testing distribution - Worst bias is the 19-bit window at bit 43 - 0.036%
+Testing collisions (high 32-bit) - Expected       1862.1, actual   1864 (1.00x) (2)
+Testing collisions (high 25-38 bits) - Worst is 38 bits: 41/29 (1.41x)
+Testing collisions (low  32-bit) - Expected       1862.1, actual   1930 (1.04x) (68)
+Testing collisions (low  25-38 bits) - Worst is 35 bits: 251/232 (1.08x)
+Testing distribution - Worst bias is the 19-bit window at bit 51 - 0.057%
 
 Keyset 'Words' - 4000000 random keys of len 6-16 from password charset
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected       1862.6, actual   1896 (1.02x) (34)
-Testing collisions (high 25-38 bits) - Worst is 38 bits: 37/29 (1.27x)
-Testing collisions (high 12-bit) - Expected    3995904.0, actual 3995904 (1.00x)
-Testing collisions (high  8-bit) - Expected    3999744.0, actual 3999744 (1.00x)
-Testing collisions (low  32-bit) - Expected       1862.6, actual   1838 (0.99x) (-24)
-Testing collisions (low  25-38 bits) - Worst is 38 bits: 34/29 (1.17x)
-Testing collisions (low  12-bit) - Expected    3995904.0, actual 3995904 (1.00x)
-Testing collisions (low   8-bit) - Expected    3999744.0, actual 3999744 (1.00x)
-Testing distribution - Worst bias is the 19-bit window at bit  5 - 0.062%
+Testing collisions (high 32-bit) - Expected       1862.1, actual   1875 (1.01x) (13)
+Testing collisions (high 25-38 bits) - Worst is 33 bits: 954/931 (1.02x)
+Testing collisions (low  32-bit) - Expected       1862.1, actual   1891 (1.02x) (29)
+Testing collisions (low  25-38 bits) - Worst is 38 bits: 31/29 (1.07x)
+Testing distribution - Worst bias is the 19-bit window at bit 36 - 0.055%
 
-Keyset 'Words' - 102401 dict words
+Keyset 'Words' - 104334 dict words
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected          1.2, actual      1 (0.82x)
-Testing collisions (high 20-27 bits) - Worst is 26 bits: 84/78 (1.08x)
-Testing collisions (high 12-bit) - Expected      98305.0, actual  98305 (1.00x)
-Testing collisions (high  8-bit) - Expected     102145.0, actual 102145 (1.00x)
-Testing collisions (low  32-bit) - Expected          1.2, actual      0 (0.00x)
-Testing collisions (low  20-27 bits) - Worst is 23 bits: 627/625 (1.00x)
-Testing collisions (low  12-bit) - Expected      98305.0, actual  98305 (1.00x)
-Testing collisions (low   8-bit) - Expected     102145.0, actual 102145 (1.00x)
-Testing distribution - Worst bias is the 14-bit window at bit 30 - 0.375%
+Testing collisions (high 32-bit) - Expected          1.3, actual      0 (0.00x)
+Testing collisions (high 20-28 bits) - Worst is 21 bits: 2566/2552 (1.01x)
+Testing collisions (low  32-bit) - Expected          1.3, actual      1 (0.79x)
+Testing collisions (low  20-28 bits) - Worst is 22 bits: 1301/1286 (1.01x)
+Testing distribution - Worst bias is the 14-bit window at bit 35 - 0.260%
 
 
 [[[ Keyset 'Zeroes' Tests ]]]
 
 Keyset 'Zeroes' - 204800 keys
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected          4.9, actual      6 (1.23x) (2)
-Testing collisions (high 21-29 bits) - Worst is 29 bits: 44/39 (1.13x)
-Testing collisions (high 12-bit) - Expected     200704.0, actual 200704 (1.00x)
-Testing collisions (high  8-bit) - Expected     204544.0, actual 204544 (1.00x)
-Testing collisions (low  32-bit) - Expected          4.9, actual      3 (0.61x)
-Testing collisions (low  21-29 bits) - Worst is 28 bits: 104/78 (1.33x)
-Testing collisions (low  12-bit) - Expected     200704.0, actual 200704 (1.00x)
-Testing collisions (low   8-bit) - Expected     204544.0, actual 204544 (1.00x)
-Testing distribution - Worst bias is the 15-bit window at bit  2 - 0.298%
+Testing collisions (high 32-bit) - Expected          4.9, actual      8 (1.64x) (4)
+Testing collisions (high 21-29 bits) - Worst is 27 bits: 161/156 (1.03x)
+Testing collisions (low  32-bit) - Expected          4.9, actual      4 (0.82x)
+Testing collisions (low  21-29 bits) - Worst is 26 bits: 317/312 (1.02x)
+Testing distribution - Worst bias is the 15-bit window at bit 51 - 0.517%
 
 
 [[[ Keyset 'Seed' Tests ]]]
 
 Keyset 'Seed' - 5000000 keys
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected       2910.4, actual   2971 (1.02x) (61)
-Testing collisions (high 26-39 bits) - Worst is 39 bits: 27/22 (1.19x)
-Testing collisions (high 12-bit) - Expected    4995904.0, actual 4995904 (1.00x)
-Testing collisions (high  8-bit) - Expected    4999744.0, actual 4999744 (1.00x)
-Testing collisions (low  32-bit) - Expected       2910.4, actual   2876 (0.99x) (-34)
-Testing collisions (low  26-39 bits) - Worst is 33 bits: 1502/1455 (1.03x)
-Testing collisions (low  12-bit) - Expected    4995904.0, actual 4995904 (1.00x)
-Testing collisions (low   8-bit) - Expected    4999744.0, actual 4999744 (1.00x)
-Testing distribution - Worst bias is the 19-bit window at bit 60 - 0.051%
+Testing collisions (high 32-bit) - Expected       2909.3, actual   2977 (1.02x) (68)
+Testing collisions (high 26-39 bits) - Worst is 38 bits: 52/45 (1.14x)
+Testing collisions (low  32-bit) - Expected       2909.3, actual   2918 (1.00x) (9)
+Testing collisions (low  26-39 bits) - Worst is 37 bits: 100/90 (1.10x)
+Testing distribution - Worst bias is the 19-bit window at bit 54 - 0.037%
 
 
 [[[ Keyset 'PerlinNoise' Tests ]]]
 
 Testing 16777216 coordinates (L2) :
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected      32768.0, actual  32732 (1.00x) (-35)
-Testing collisions (high 27-42 bits) - Worst is 41 bits: 66/63 (1.03x)
-Testing collisions (high 12-bit) - Expected   16773120.0, actual 16773120 (1.00x)
-Testing collisions (high  8-bit) - Expected   16776960.0, actual 16776960 (1.00x)
-Testing collisions (low  32-bit) - Expected      32768.0, actual  32429 (0.99x) (-338)
-Testing collisions (low  27-42 bits) - Worst is 42 bits: 39/31 (1.22x)
-Testing collisions (low  12-bit) - Expected   16773120.0, actual 16773120 (1.00x)
-Testing collisions (low   8-bit) - Expected   16776960.0, actual 16776960 (1.00x)
+Testing collisions (high 32-bit) - Expected      32725.4, actual  32878 (1.00x) (153)
+Testing collisions (high 27-42 bits) - Worst is 34 bits: 8352/8189 (1.02x)
+Testing collisions (low  32-bit) - Expected      32725.4, actual  32870 (1.00x) (145)
+Testing collisions (low  27-42 bits) - Worst is 34 bits: 8327/8189 (1.02x)
+
+Testing AV variant, 128 count with 4 spacing, 4-12:
+Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
+Testing collisions (high 32-bit) - Expected       1116.2, actual   1100 (0.99x) (-16)
+Testing collisions (high 25-37 bits) - Worst is 37 bits: 36/34 (1.03x)
+Testing collisions (low  32-bit) - Expected       1116.2, actual   1150 (1.03x) (34)
+Testing collisions (low  25-37 bits) - Worst is 33 bits: 584/558 (1.05x)
 
 
 [[[ Diff 'Differential' Tests ]]]
@@ -776,741 +587,551 @@ Testing 2796416 up-to-3-bit differentials in 256-bit keys -> 64 bit hashes.
 
 Testing bit 0
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected        512.0, actual    542 (1.06x) (31)
-Testing collisions (high 24-36 bits) - Worst is 35 bits: 69/63 (1.08x)
-Testing collisions (high 12-bit) - Expected    2093056.0, actual 2093056 (1.00x)
-Testing collisions (high  8-bit) - Expected    2096896.0, actual 2096896 (1.00x)
-Testing collisions (low  32-bit) - Expected        512.0, actual    592 (1.16x) (81)
-Testing collisions (low  24-36 bits) - Worst is 36 bits: 40/31 (1.25x)
-Testing collisions (low  12-bit) - Expected    2093056.0, actual 2093056 (1.00x)
-Testing collisions (low   8-bit) - Expected    2096896.0, actual 2096896 (1.00x)
+Testing collisions (high 32-bit) - Expected        511.9, actual    525 (1.03x) (14)
+Testing collisions (high 24-36 bits) - Worst is 33 bits: 289/255 (1.13x)
+Testing collisions (low  32-bit) - Expected        511.9, actual    555 (1.08x) (44)
+Testing collisions (low  24-36 bits) - Worst is 34 bits: 141/127 (1.10x)
+Testing distribution - Worst bias is the 18-bit window at bit 45 - 0.075%
 
 Testing bit 1
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected        512.0, actual    503 (0.98x) (-8)
-Testing collisions (high 24-36 bits) - Worst is 31 bits: 1015/1023 (0.99x)
-Testing collisions (high 12-bit) - Expected    2093056.0, actual 2093056 (1.00x)
-Testing collisions (high  8-bit) - Expected    2096896.0, actual 2096896 (1.00x)
-Testing collisions (low  32-bit) - Expected        512.0, actual    495 (0.97x)
-Testing collisions (low  24-36 bits) - Worst is 33 bits: 262/255 (1.02x)
-Testing collisions (low  12-bit) - Expected    2093056.0, actual 2093056 (1.00x)
-Testing collisions (low   8-bit) - Expected    2096896.0, actual 2096896 (1.00x)
+Testing collisions (high 32-bit) - Expected        511.9, actual    514 (1.00x) (3)
+Testing collisions (high 24-36 bits) - Worst is 31 bits: 1045/1023 (1.02x)
+Testing collisions (low  32-bit) - Expected        511.9, actual    543 (1.06x) (32)
+Testing collisions (low  24-36 bits) - Worst is 36 bits: 41/31 (1.28x)
+Testing distribution - Worst bias is the 18-bit window at bit 33 - 0.083%
 
 Testing bit 2
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected        512.0, actual    521 (1.02x) (10)
-Testing collisions (high 24-36 bits) - Worst is 32 bits: 521/511 (1.02x)
-Testing collisions (high 12-bit) - Expected    2093056.0, actual 2093056 (1.00x)
-Testing collisions (high  8-bit) - Expected    2096896.0, actual 2096896 (1.00x)
-Testing collisions (low  32-bit) - Expected        512.0, actual    535 (1.04x) (24)
-Testing collisions (low  24-36 bits) - Worst is 36 bits: 41/31 (1.28x)
-Testing collisions (low  12-bit) - Expected    2093056.0, actual 2093056 (1.00x)
-Testing collisions (low   8-bit) - Expected    2096896.0, actual 2096896 (1.00x)
+Testing collisions (high 32-bit) - Expected        511.9, actual    493 (0.96x)
+Testing collisions (high 24-36 bits) - Worst is 26 bits: 32575/32429 (1.00x)
+Testing collisions (low  32-bit) - Expected        511.9, actual    519 (1.01x) (8)
+Testing collisions (low  24-36 bits) - Worst is 34 bits: 134/127 (1.05x)
+Testing distribution - Worst bias is the 18-bit window at bit 43 - 0.101%
 
 Testing bit 3
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected        512.0, actual    495 (0.97x)
-Testing collisions (high 24-36 bits) - Worst is 34 bits: 139/127 (1.09x)
-Testing collisions (high 12-bit) - Expected    2093056.0, actual 2093056 (1.00x)
-Testing collisions (high  8-bit) - Expected    2096896.0, actual 2096896 (1.00x)
-Testing collisions (low  32-bit) - Expected        512.0, actual    554 (1.08x) (43)
-Testing collisions (low  24-36 bits) - Worst is 34 bits: 155/127 (1.21x)
-Testing collisions (low  12-bit) - Expected    2093056.0, actual 2093056 (1.00x)
-Testing collisions (low   8-bit) - Expected    2096896.0, actual 2096896 (1.00x)
+Testing collisions (high 32-bit) - Expected        511.9, actual    511 (1.00x)
+Testing collisions (high 24-36 bits) - Worst is 35 bits: 78/63 (1.22x)
+Testing collisions (low  32-bit) - Expected        511.9, actual    521 (1.02x) (10)
+Testing collisions (low  24-36 bits) - Worst is 35 bits: 77/63 (1.20x)
+Testing distribution - Worst bias is the 18-bit window at bit 31 - 0.067%
 
 Testing bit 4
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected        512.0, actual    535 (1.04x) (24)
-Testing collisions (high 24-36 bits) - Worst is 32 bits: 535/511 (1.04x)
-Testing collisions (high 12-bit) - Expected    2093056.0, actual 2093056 (1.00x)
-Testing collisions (high  8-bit) - Expected    2096896.0, actual 2096896 (1.00x)
-Testing collisions (low  32-bit) - Expected        512.0, actual    505 (0.99x) (-6)
-Testing collisions (low  24-36 bits) - Worst is 29 bits: 4137/4095 (1.01x)
-Testing collisions (low  12-bit) - Expected    2093056.0, actual 2093056 (1.00x)
-Testing collisions (low   8-bit) - Expected    2096896.0, actual 2096896 (1.00x)
+Testing collisions (high 32-bit) - Expected        511.9, actual    483 (0.94x)
+Testing collisions (high 24-36 bits) - Worst is 36 bits: 36/31 (1.13x)
+Testing collisions (low  32-bit) - Expected        511.9, actual    492 (0.96x)
+Testing collisions (low  24-36 bits) - Worst is 25 bits: 64466/64191 (1.00x)
+Testing distribution - Worst bias is the 17-bit window at bit 36 - 0.052%
 
 Testing bit 5
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected        512.0, actual    527 (1.03x) (16)
-Testing collisions (high 24-36 bits) - Worst is 36 bits: 40/31 (1.25x)
-Testing collisions (high 12-bit) - Expected    2093056.0, actual 2093056 (1.00x)
-Testing collisions (high  8-bit) - Expected    2096896.0, actual 2096896 (1.00x)
-Testing collisions (low  32-bit) - Expected        512.0, actual    539 (1.05x) (28)
-Testing collisions (low  24-36 bits) - Worst is 35 bits: 74/63 (1.16x)
-Testing collisions (low  12-bit) - Expected    2093056.0, actual 2093056 (1.00x)
-Testing collisions (low   8-bit) - Expected    2096896.0, actual 2096896 (1.00x)
+Testing collisions (high 32-bit) - Expected        511.9, actual    519 (1.01x) (8)
+Testing collisions (high 24-36 bits) - Worst is 36 bits: 39/31 (1.22x)
+Testing collisions (low  32-bit) - Expected        511.9, actual    542 (1.06x) (31)
+Testing collisions (low  24-36 bits) - Worst is 35 bits: 77/63 (1.20x)
+Testing distribution - Worst bias is the 18-bit window at bit 38 - 0.055%
 
 Testing bit 6
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected        512.0, actual    520 (1.02x) (9)
-Testing collisions (high 24-36 bits) - Worst is 33 bits: 269/255 (1.05x)
-Testing collisions (high 12-bit) - Expected    2093056.0, actual 2093056 (1.00x)
-Testing collisions (high  8-bit) - Expected    2096896.0, actual 2096896 (1.00x)
-Testing collisions (low  32-bit) - Expected        512.0, actual    480 (0.94x)
-Testing collisions (low  24-36 bits) - Worst is 36 bits: 33/31 (1.03x)
-Testing collisions (low  12-bit) - Expected    2093056.0, actual 2093056 (1.00x)
-Testing collisions (low   8-bit) - Expected    2096896.0, actual 2096896 (1.00x)
+Testing collisions (high 32-bit) - Expected        511.9, actual    549 (1.07x) (38)
+Testing collisions (high 24-36 bits) - Worst is 31 bits: 1115/1023 (1.09x)
+Testing collisions (low  32-bit) - Expected        511.9, actual    547 (1.07x) (36)
+Testing collisions (low  24-36 bits) - Worst is 36 bits: 40/31 (1.25x)
+Testing distribution - Worst bias is the 18-bit window at bit  4 - 0.116%
 
 Testing bit 7
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected        512.0, actual    542 (1.06x) (31)
-Testing collisions (high 24-36 bits) - Worst is 36 bits: 42/31 (1.31x)
-Testing collisions (high 12-bit) - Expected    2093056.0, actual 2093056 (1.00x)
-Testing collisions (high  8-bit) - Expected    2096896.0, actual 2096896 (1.00x)
-Testing collisions (low  32-bit) - Expected        512.0, actual    487 (0.95x)
-Testing collisions (low  24-36 bits) - Worst is 29 bits: 4169/4095 (1.02x)
-Testing collisions (low  12-bit) - Expected    2093056.0, actual 2093056 (1.00x)
-Testing collisions (low   8-bit) - Expected    2096896.0, actual 2096896 (1.00x)
+Testing collisions (high 32-bit) - Expected        511.9, actual    515 (1.01x) (4)
+Testing collisions (high 24-36 bits) - Worst is 36 bits: 33/31 (1.03x)
+Testing collisions (low  32-bit) - Expected        511.9, actual    483 (0.94x)
+Testing collisions (low  24-36 bits) - Worst is 24 bits: 125823/125777 (1.00x)
+Testing distribution - Worst bias is the 18-bit window at bit 62 - 0.067%
 
 Testing bit 8
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected        512.0, actual    513 (1.00x) (2)
-Testing collisions (high 24-36 bits) - Worst is 32 bits: 513/511 (1.00x)
-Testing collisions (high 12-bit) - Expected    2093056.0, actual 2093056 (1.00x)
-Testing collisions (high  8-bit) - Expected    2096896.0, actual 2096896 (1.00x)
-Testing collisions (low  32-bit) - Expected        512.0, actual    556 (1.09x) (45)
-Testing collisions (low  24-36 bits) - Worst is 36 bits: 36/31 (1.13x)
-Testing collisions (low  12-bit) - Expected    2093056.0, actual 2093056 (1.00x)
-Testing collisions (low   8-bit) - Expected    2096896.0, actual 2096896 (1.00x)
+Testing collisions (high 32-bit) - Expected        511.9, actual    514 (1.00x) (3)
+Testing collisions (high 24-36 bits) - Worst is 31 bits: 1051/1023 (1.03x)
+Testing collisions (low  32-bit) - Expected        511.9, actual    511 (1.00x)
+Testing collisions (low  24-36 bits) - Worst is 35 bits: 67/63 (1.05x)
+Testing distribution - Worst bias is the 18-bit window at bit 36 - 0.091%
 
 Testing bit 9
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected        512.0, actual    514 (1.00x) (3)
-Testing collisions (high 24-36 bits) - Worst is 32 bits: 514/511 (1.00x)
-Testing collisions (high 12-bit) - Expected    2093056.0, actual 2093056 (1.00x)
-Testing collisions (high  8-bit) - Expected    2096896.0, actual 2096896 (1.00x)
-Testing collisions (low  32-bit) - Expected        512.0, actual    517 (1.01x) (6)
-Testing collisions (low  24-36 bits) - Worst is 35 bits: 69/63 (1.08x)
-Testing collisions (low  12-bit) - Expected    2093056.0, actual 2093056 (1.00x)
-Testing collisions (low   8-bit) - Expected    2096896.0, actual 2096896 (1.00x)
+Testing collisions (high 32-bit) - Expected        511.9, actual    524 (1.02x) (13)
+Testing collisions (high 24-36 bits) - Worst is 33 bits: 264/255 (1.03x)
+Testing collisions (low  32-bit) - Expected        511.9, actual    514 (1.00x) (3)
+Testing collisions (low  24-36 bits) - Worst is 36 bits: 45/31 (1.41x)
+Testing distribution - Worst bias is the 18-bit window at bit 42 - 0.069%
 
 Testing bit 10
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected        512.0, actual    506 (0.99x) (-5)
-Testing collisions (high 24-36 bits) - Worst is 34 bits: 128/127 (1.00x)
-Testing collisions (high 12-bit) - Expected    2093056.0, actual 2093056 (1.00x)
-Testing collisions (high  8-bit) - Expected    2096896.0, actual 2096896 (1.00x)
-Testing collisions (low  32-bit) - Expected        512.0, actual    502 (0.98x) (-9)
-Testing collisions (low  24-36 bits) - Worst is 35 bits: 69/63 (1.08x)
-Testing collisions (low  12-bit) - Expected    2093056.0, actual 2093056 (1.00x)
-Testing collisions (low   8-bit) - Expected    2096896.0, actual 2096896 (1.00x)
+Testing collisions (high 32-bit) - Expected        511.9, actual    502 (0.98x) (-9)
+Testing collisions (high 24-36 bits) - Worst is 35 bits: 75/63 (1.17x)
+Testing collisions (low  32-bit) - Expected        511.9, actual    503 (0.98x) (-8)
+Testing collisions (low  24-36 bits) - Worst is 30 bits: 2102/2046 (1.03x)
+Testing distribution - Worst bias is the 17-bit window at bit 43 - 0.085%
 
 Testing bit 11
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected        512.0, actual    482 (0.94x)
-Testing collisions (high 24-36 bits) - Worst is 28 bits: 8202/8191 (1.00x)
-Testing collisions (high 12-bit) - Expected    2093056.0, actual 2093056 (1.00x)
-Testing collisions (high  8-bit) - Expected    2096896.0, actual 2096896 (1.00x)
-Testing collisions (low  32-bit) - Expected        512.0, actual    494 (0.96x)
-Testing collisions (low  24-36 bits) - Worst is 36 bits: 40/31 (1.25x)
-Testing collisions (low  12-bit) - Expected    2093056.0, actual 2093056 (1.00x)
-Testing collisions (low   8-bit) - Expected    2096896.0, actual 2096896 (1.00x)
+Testing collisions (high 32-bit) - Expected        511.9, actual    480 (0.94x)
+Testing collisions (high 24-36 bits) - Worst is 30 bits: 2073/2046 (1.01x)
+Testing collisions (low  32-bit) - Expected        511.9, actual    527 (1.03x) (16)
+Testing collisions (low  24-36 bits) - Worst is 32 bits: 527/511 (1.03x)
+Testing distribution - Worst bias is the 18-bit window at bit 60 - 0.112%
 
 Testing bit 12
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected        512.0, actual    531 (1.04x) (20)
-Testing collisions (high 24-36 bits) - Worst is 32 bits: 531/511 (1.04x)
-Testing collisions (high 12-bit) - Expected    2093056.0, actual 2093056 (1.00x)
-Testing collisions (high  8-bit) - Expected    2096896.0, actual 2096896 (1.00x)
-Testing collisions (low  32-bit) - Expected        512.0, actual    533 (1.04x) (22)
-Testing collisions (low  24-36 bits) - Worst is 33 bits: 272/255 (1.06x)
-Testing collisions (low  12-bit) - Expected    2093056.0, actual 2093056 (1.00x)
-Testing collisions (low   8-bit) - Expected    2096896.0, actual 2096896 (1.00x)
+Testing collisions (high 32-bit) - Expected        511.9, actual    513 (1.00x) (2)
+Testing collisions (high 24-36 bits) - Worst is 35 bits: 71/63 (1.11x)
+Testing collisions (low  32-bit) - Expected        511.9, actual    524 (1.02x) (13)
+Testing collisions (low  24-36 bits) - Worst is 33 bits: 265/255 (1.04x)
+Testing distribution - Worst bias is the 18-bit window at bit 35 - 0.068%
 
 Testing bit 13
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected        512.0, actual    539 (1.05x) (28)
-Testing collisions (high 24-36 bits) - Worst is 36 bits: 42/31 (1.31x)
-Testing collisions (high 12-bit) - Expected    2093056.0, actual 2093056 (1.00x)
-Testing collisions (high  8-bit) - Expected    2096896.0, actual 2096896 (1.00x)
-Testing collisions (low  32-bit) - Expected        512.0, actual    562 (1.10x) (51)
-Testing collisions (low  24-36 bits) - Worst is 34 bits: 160/127 (1.25x)
-Testing collisions (low  12-bit) - Expected    2093056.0, actual 2093056 (1.00x)
-Testing collisions (low   8-bit) - Expected    2096896.0, actual 2096896 (1.00x)
+Testing collisions (high 32-bit) - Expected        511.9, actual    559 (1.09x) (48)
+Testing collisions (high 24-36 bits) - Worst is 35 bits: 73/63 (1.14x)
+Testing collisions (low  32-bit) - Expected        511.9, actual    555 (1.08x) (44)
+Testing collisions (low  24-36 bits) - Worst is 34 bits: 150/127 (1.17x)
+Testing distribution - Worst bias is the 18-bit window at bit 26 - 0.103%
 
 Testing bit 14
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected        512.0, actual    510 (1.00x) (-1)
-Testing collisions (high 24-36 bits) - Worst is 36 bits: 46/31 (1.44x)
-Testing collisions (high 12-bit) - Expected    2093056.0, actual 2093056 (1.00x)
-Testing collisions (high  8-bit) - Expected    2096896.0, actual 2096896 (1.00x)
-Testing collisions (low  32-bit) - Expected        512.0, actual    506 (0.99x) (-5)
-Testing collisions (low  24-36 bits) - Worst is 33 bits: 269/255 (1.05x)
-Testing collisions (low  12-bit) - Expected    2093056.0, actual 2093056 (1.00x)
-Testing collisions (low   8-bit) - Expected    2096896.0, actual 2096896 (1.00x)
+Testing collisions (high 32-bit) - Expected        511.9, actual    512 (1.00x) (1)
+Testing collisions (high 24-36 bits) - Worst is 34 bits: 134/127 (1.05x)
+Testing collisions (low  32-bit) - Expected        511.9, actual    506 (0.99x) (-5)
+Testing collisions (low  24-36 bits) - Worst is 35 bits: 69/63 (1.08x)
+Testing distribution - Worst bias is the 18-bit window at bit 28 - 0.064%
 
 Testing bit 15
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected        512.0, actual    544 (1.06x) (33)
-Testing collisions (high 24-36 bits) - Worst is 33 bits: 279/255 (1.09x)
-Testing collisions (high 12-bit) - Expected    2093056.0, actual 2093056 (1.00x)
-Testing collisions (high  8-bit) - Expected    2096896.0, actual 2096896 (1.00x)
-Testing collisions (low  32-bit) - Expected        512.0, actual    495 (0.97x)
-Testing collisions (low  24-36 bits) - Worst is 36 bits: 36/31 (1.13x)
-Testing collisions (low  12-bit) - Expected    2093056.0, actual 2093056 (1.00x)
-Testing collisions (low   8-bit) - Expected    2096896.0, actual 2096896 (1.00x)
+Testing collisions (high 32-bit) - Expected        511.9, actual    526 (1.03x) (15)
+Testing collisions (high 24-36 bits) - Worst is 32 bits: 526/511 (1.03x)
+Testing collisions (low  32-bit) - Expected        511.9, actual    532 (1.04x) (21)
+Testing collisions (low  24-36 bits) - Worst is 31 bits: 1067/1023 (1.04x)
+Testing distribution - Worst bias is the 18-bit window at bit 18 - 0.076%
 
 Testing bit 16
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected        512.0, actual    518 (1.01x) (7)
-Testing collisions (high 24-36 bits) - Worst is 35 bits: 66/63 (1.03x)
-Testing collisions (high 12-bit) - Expected    2093056.0, actual 2093056 (1.00x)
-Testing collisions (high  8-bit) - Expected    2096896.0, actual 2096896 (1.00x)
-Testing collisions (low  32-bit) - Expected        512.0, actual    504 (0.98x) (-7)
-Testing collisions (low  24-36 bits) - Worst is 36 bits: 46/31 (1.44x)
-Testing collisions (low  12-bit) - Expected    2093056.0, actual 2093056 (1.00x)
-Testing collisions (low   8-bit) - Expected    2096896.0, actual 2096896 (1.00x)
+Testing collisions (high 32-bit) - Expected        511.9, actual    542 (1.06x) (31)
+Testing collisions (high 24-36 bits) - Worst is 33 bits: 291/255 (1.14x)
+Testing collisions (low  32-bit) - Expected        511.9, actual    481 (0.94x)
+Testing collisions (low  24-36 bits) - Worst is 36 bits: 36/31 (1.13x)
+Testing distribution - Worst bias is the 18-bit window at bit 49 - 0.077%
 
 Testing bit 17
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected        512.0, actual    520 (1.02x) (9)
-Testing collisions (high 24-36 bits) - Worst is 34 bits: 140/127 (1.09x)
-Testing collisions (high 12-bit) - Expected    2093056.0, actual 2093056 (1.00x)
-Testing collisions (high  8-bit) - Expected    2096896.0, actual 2096896 (1.00x)
-Testing collisions (low  32-bit) - Expected        512.0, actual    492 (0.96x)
-Testing collisions (low  24-36 bits) - Worst is 28 bits: 8152/8191 (1.00x)
-Testing collisions (low  12-bit) - Expected    2093056.0, actual 2093056 (1.00x)
-Testing collisions (low   8-bit) - Expected    2096896.0, actual 2096896 (1.00x)
+Testing collisions (high 32-bit) - Expected        511.9, actual    527 (1.03x) (16)
+Testing collisions (high 24-36 bits) - Worst is 36 bits: 37/31 (1.16x)
+Testing collisions (low  32-bit) - Expected        511.9, actual    546 (1.07x) (35)
+Testing collisions (low  24-36 bits) - Worst is 35 bits: 75/63 (1.17x)
+Testing distribution - Worst bias is the 18-bit window at bit 56 - 0.079%
 
 Testing bit 18
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected        512.0, actual    518 (1.01x) (7)
-Testing collisions (high 24-36 bits) - Worst is 35 bits: 73/63 (1.14x)
-Testing collisions (high 12-bit) - Expected    2093056.0, actual 2093056 (1.00x)
-Testing collisions (high  8-bit) - Expected    2096896.0, actual 2096896 (1.00x)
-Testing collisions (low  32-bit) - Expected        512.0, actual    533 (1.04x) (22)
-Testing collisions (low  24-36 bits) - Worst is 36 bits: 37/31 (1.16x)
-Testing collisions (low  12-bit) - Expected    2093056.0, actual 2093056 (1.00x)
-Testing collisions (low   8-bit) - Expected    2096896.0, actual 2096896 (1.00x)
+Testing collisions (high 32-bit) - Expected        511.9, actual    502 (0.98x) (-9)
+Testing collisions (high 24-36 bits) - Worst is 36 bits: 35/31 (1.09x)
+Testing collisions (low  32-bit) - Expected        511.9, actual    498 (0.97x)
+Testing collisions (low  24-36 bits) - Worst is 34 bits: 130/127 (1.02x)
+Testing distribution - Worst bias is the 18-bit window at bit 16 - 0.066%
 
 Testing bit 19
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected        512.0, actual    528 (1.03x) (17)
-Testing collisions (high 24-36 bits) - Worst is 32 bits: 528/511 (1.03x)
-Testing collisions (high 12-bit) - Expected    2093056.0, actual 2093056 (1.00x)
-Testing collisions (high  8-bit) - Expected    2096896.0, actual 2096896 (1.00x)
-Testing collisions (low  32-bit) - Expected        512.0, actual    537 (1.05x) (26)
-Testing collisions (low  24-36 bits) - Worst is 36 bits: 38/31 (1.19x)
-Testing collisions (low  12-bit) - Expected    2093056.0, actual 2093056 (1.00x)
-Testing collisions (low   8-bit) - Expected    2096896.0, actual 2096896 (1.00x)
+Testing collisions (high 32-bit) - Expected        511.9, actual    522 (1.02x) (11)
+Testing collisions (high 24-36 bits) - Worst is 33 bits: 264/255 (1.03x)
+Testing collisions (low  32-bit) - Expected        511.9, actual    559 (1.09x) (48)
+Testing collisions (low  24-36 bits) - Worst is 33 bits: 281/255 (1.10x)
+Testing distribution - Worst bias is the 18-bit window at bit 20 - 0.089%
 
 Testing bit 20
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected        512.0, actual    510 (1.00x) (-1)
-Testing collisions (high 24-36 bits) - Worst is 30 bits: 2093/2047 (1.02x)
-Testing collisions (high 12-bit) - Expected    2093056.0, actual 2093056 (1.00x)
-Testing collisions (high  8-bit) - Expected    2096896.0, actual 2096896 (1.00x)
-Testing collisions (low  32-bit) - Expected        512.0, actual    549 (1.07x) (38)
-Testing collisions (low  24-36 bits) - Worst is 31 bits: 1098/1023 (1.07x)
-Testing collisions (low  12-bit) - Expected    2093056.0, actual 2093056 (1.00x)
-Testing collisions (low   8-bit) - Expected    2096896.0, actual 2096896 (1.00x)
+Testing collisions (high 32-bit) - Expected        511.9, actual    547 (1.07x) (36)
+Testing collisions (high 24-36 bits) - Worst is 35 bits: 71/63 (1.11x)
+Testing collisions (low  32-bit) - Expected        511.9, actual    524 (1.02x) (13)
+Testing collisions (low  24-36 bits) - Worst is 34 bits: 139/127 (1.09x)
+Testing distribution - Worst bias is the 18-bit window at bit 27 - 0.064%
 
 Testing bit 21
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected        512.0, actual    501 (0.98x)
-Testing collisions (high 24-36 bits) - Worst is 35 bits: 73/63 (1.14x)
-Testing collisions (high 12-bit) - Expected    2093056.0, actual 2093056 (1.00x)
-Testing collisions (high  8-bit) - Expected    2096896.0, actual 2096896 (1.00x)
-Testing collisions (low  32-bit) - Expected        512.0, actual    514 (1.00x) (3)
-Testing collisions (low  24-36 bits) - Worst is 35 bits: 67/63 (1.05x)
-Testing collisions (low  12-bit) - Expected    2093056.0, actual 2093056 (1.00x)
-Testing collisions (low   8-bit) - Expected    2096896.0, actual 2096896 (1.00x)
+Testing collisions (high 32-bit) - Expected        511.9, actual    487 (0.95x)
+Testing collisions (high 24-36 bits) - Worst is 34 bits: 135/127 (1.05x)
+Testing collisions (low  32-bit) - Expected        511.9, actual    510 (1.00x) (-1)
+Testing collisions (low  24-36 bits) - Worst is 35 bits: 69/63 (1.08x)
+Testing distribution - Worst bias is the 18-bit window at bit 34 - 0.091%
 
 Testing bit 22
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected        512.0, actual    488 (0.95x)
-Testing collisions (high 24-36 bits) - Worst is 36 bits: 36/31 (1.13x)
-Testing collisions (high 12-bit) - Expected    2093056.0, actual 2093056 (1.00x)
-Testing collisions (high  8-bit) - Expected    2096896.0, actual 2096896 (1.00x)
-Testing collisions (low  32-bit) - Expected        512.0, actual    537 (1.05x) (26)
-Testing collisions (low  24-36 bits) - Worst is 36 bits: 43/31 (1.34x)
-Testing collisions (low  12-bit) - Expected    2093056.0, actual 2093056 (1.00x)
-Testing collisions (low   8-bit) - Expected    2096896.0, actual 2096896 (1.00x)
+Testing collisions (high 32-bit) - Expected        511.9, actual    517 (1.01x) (6)
+Testing collisions (high 24-36 bits) - Worst is 33 bits: 269/255 (1.05x)
+Testing collisions (low  32-bit) - Expected        511.9, actual    490 (0.96x)
+Testing collisions (low  24-36 bits) - Worst is 29 bits: 4116/4090 (1.01x)
+Testing distribution - Worst bias is the 18-bit window at bit 55 - 0.120%
 
 Testing bit 23
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected        512.0, actual    546 (1.07x) (35)
-Testing collisions (high 24-36 bits) - Worst is 33 bits: 278/255 (1.09x)
-Testing collisions (high 12-bit) - Expected    2093056.0, actual 2093056 (1.00x)
-Testing collisions (high  8-bit) - Expected    2096896.0, actual 2096896 (1.00x)
-Testing collisions (low  32-bit) - Expected        512.0, actual    514 (1.00x) (3)
-Testing collisions (low  24-36 bits) - Worst is 33 bits: 260/255 (1.02x)
-Testing collisions (low  12-bit) - Expected    2093056.0, actual 2093056 (1.00x)
-Testing collisions (low   8-bit) - Expected    2096896.0, actual 2096896 (1.00x)
+Testing collisions (high 32-bit) - Expected        511.9, actual    480 (0.94x)
+Testing collisions (high 24-36 bits) - Worst is 36 bits: 33/31 (1.03x)
+Testing collisions (low  32-bit) - Expected        511.9, actual    508 (0.99x) (-3)
+Testing collisions (low  24-36 bits) - Worst is 30 bits: 2076/2046 (1.01x)
+Testing distribution - Worst bias is the 18-bit window at bit  5 - 0.060%
 
 Testing bit 24
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected        512.0, actual    508 (0.99x) (-3)
-Testing collisions (high 24-36 bits) - Worst is 32 bits: 508/511 (0.99x)
-Testing collisions (high 12-bit) - Expected    2093056.0, actual 2093056 (1.00x)
-Testing collisions (high  8-bit) - Expected    2096896.0, actual 2096896 (1.00x)
-Testing collisions (low  32-bit) - Expected        512.0, actual    506 (0.99x) (-5)
-Testing collisions (low  24-36 bits) - Worst is 36 bits: 36/31 (1.13x)
-Testing collisions (low  12-bit) - Expected    2093056.0, actual 2093056 (1.00x)
-Testing collisions (low   8-bit) - Expected    2096896.0, actual 2096896 (1.00x)
+Testing collisions (high 32-bit) - Expected        511.9, actual    493 (0.96x)
+Testing collisions (high 24-36 bits) - Worst is 36 bits: 39/31 (1.22x)
+Testing collisions (low  32-bit) - Expected        511.9, actual    492 (0.96x)
+Testing collisions (low  24-36 bits) - Worst is 30 bits: 2079/2046 (1.02x)
+Testing distribution - Worst bias is the 18-bit window at bit 54 - 0.078%
 
 Testing bit 25
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected        512.0, actual    523 (1.02x) (12)
-Testing collisions (high 24-36 bits) - Worst is 35 bits: 78/63 (1.22x)
-Testing collisions (high 12-bit) - Expected    2093056.0, actual 2093056 (1.00x)
-Testing collisions (high  8-bit) - Expected    2096896.0, actual 2096896 (1.00x)
-Testing collisions (low  32-bit) - Expected        512.0, actual    508 (0.99x) (-3)
-Testing collisions (low  24-36 bits) - Worst is 29 bits: 4170/4095 (1.02x)
-Testing collisions (low  12-bit) - Expected    2093056.0, actual 2093056 (1.00x)
-Testing collisions (low   8-bit) - Expected    2096896.0, actual 2096896 (1.00x)
+Testing collisions (high 32-bit) - Expected        511.9, actual    511 (1.00x)
+Testing collisions (high 24-36 bits) - Worst is 35 bits: 65/63 (1.02x)
+Testing collisions (low  32-bit) - Expected        511.9, actual    493 (0.96x)
+Testing collisions (low  24-36 bits) - Worst is 36 bits: 33/31 (1.03x)
+Testing distribution - Worst bias is the 18-bit window at bit  7 - 0.093%
 
 Testing bit 26
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected        512.0, actual    486 (0.95x)
-Testing collisions (high 24-36 bits) - Worst is 34 bits: 140/127 (1.09x)
-Testing collisions (high 12-bit) - Expected    2093056.0, actual 2093056 (1.00x)
-Testing collisions (high  8-bit) - Expected    2096896.0, actual 2096896 (1.00x)
-Testing collisions (low  32-bit) - Expected        512.0, actual    569 (1.11x) (58)
-Testing collisions (low  24-36 bits) - Worst is 35 bits: 80/63 (1.25x)
-Testing collisions (low  12-bit) - Expected    2093056.0, actual 2093056 (1.00x)
-Testing collisions (low   8-bit) - Expected    2096896.0, actual 2096896 (1.00x)
+Testing collisions (high 32-bit) - Expected        511.9, actual    533 (1.04x) (22)
+Testing collisions (high 24-36 bits) - Worst is 35 bits: 71/63 (1.11x)
+Testing collisions (low  32-bit) - Expected        511.9, actual    514 (1.00x) (3)
+Testing collisions (low  24-36 bits) - Worst is 30 bits: 2088/2046 (1.02x)
+Testing distribution - Worst bias is the 18-bit window at bit 33 - 0.084%
 
 Testing bit 27
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected        512.0, actual    552 (1.08x) (41)
-Testing collisions (high 24-36 bits) - Worst is 35 bits: 74/63 (1.16x)
-Testing collisions (high 12-bit) - Expected    2093056.0, actual 2093056 (1.00x)
-Testing collisions (high  8-bit) - Expected    2096896.0, actual 2096896 (1.00x)
-Testing collisions (low  32-bit) - Expected        512.0, actual    544 (1.06x) (33)
-Testing collisions (low  24-36 bits) - Worst is 34 bits: 140/127 (1.09x)
-Testing collisions (low  12-bit) - Expected    2093056.0, actual 2093056 (1.00x)
-Testing collisions (low   8-bit) - Expected    2096896.0, actual 2096896 (1.00x)
+Testing collisions (high 32-bit) - Expected        511.9, actual    456 (0.89x)
+Testing collisions (high 24-36 bits) - Worst is 29 bits: 4111/4090 (1.00x)
+Testing collisions (low  32-bit) - Expected        511.9, actual    519 (1.01x) (8)
+Testing collisions (low  24-36 bits) - Worst is 31 bits: 1054/1023 (1.03x)
+Testing distribution - Worst bias is the 18-bit window at bit 24 - 0.074%
 
 Testing bit 28
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected        512.0, actual    544 (1.06x) (33)
-Testing collisions (high 24-36 bits) - Worst is 34 bits: 141/127 (1.10x)
-Testing collisions (high 12-bit) - Expected    2093056.0, actual 2093056 (1.00x)
-Testing collisions (high  8-bit) - Expected    2096896.0, actual 2096896 (1.00x)
-Testing collisions (low  32-bit) - Expected        512.0, actual    537 (1.05x) (26)
-Testing collisions (low  24-36 bits) - Worst is 36 bits: 42/31 (1.31x)
-Testing collisions (low  12-bit) - Expected    2093056.0, actual 2093056 (1.00x)
-Testing collisions (low   8-bit) - Expected    2096896.0, actual 2096896 (1.00x)
+Testing collisions (high 32-bit) - Expected        511.9, actual    528 (1.03x) (17)
+Testing collisions (high 24-36 bits) - Worst is 33 bits: 274/255 (1.07x)
+Testing collisions (low  32-bit) - Expected        511.9, actual    490 (0.96x)
+Testing collisions (low  24-36 bits) - Worst is 35 bits: 80/63 (1.25x)
+Testing distribution - Worst bias is the 18-bit window at bit 40 - 0.097%
 
 Testing bit 29
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected        512.0, actual    531 (1.04x) (20)
-Testing collisions (high 24-36 bits) - Worst is 36 bits: 43/31 (1.34x)
-Testing collisions (high 12-bit) - Expected    2093056.0, actual 2093056 (1.00x)
-Testing collisions (high  8-bit) - Expected    2096896.0, actual 2096896 (1.00x)
-Testing collisions (low  32-bit) - Expected        512.0, actual    507 (0.99x) (-4)
-Testing collisions (low  24-36 bits) - Worst is 36 bits: 33/31 (1.03x)
-Testing collisions (low  12-bit) - Expected    2093056.0, actual 2093056 (1.00x)
-Testing collisions (low   8-bit) - Expected    2096896.0, actual 2096896 (1.00x)
+Testing collisions (high 32-bit) - Expected        511.9, actual    491 (0.96x)
+Testing collisions (high 24-36 bits) - Worst is 27 bits: 16375/16298 (1.00x)
+Testing collisions (low  32-bit) - Expected        511.9, actual    505 (0.99x) (-6)
+Testing collisions (low  24-36 bits) - Worst is 24 bits: 125841/125777 (1.00x)
+Testing distribution - Worst bias is the 18-bit window at bit  3 - 0.067%
 
 Testing bit 30
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected        512.0, actual    477 (0.93x)
-Testing collisions (high 24-36 bits) - Worst is 28 bits: 8243/8191 (1.01x)
-Testing collisions (high 12-bit) - Expected    2093056.0, actual 2093056 (1.00x)
-Testing collisions (high  8-bit) - Expected    2096896.0, actual 2096896 (1.00x)
-Testing collisions (low  32-bit) - Expected        512.0, actual    497 (0.97x)
-Testing collisions (low  24-36 bits) - Worst is 35 bits: 77/63 (1.20x)
-Testing collisions (low  12-bit) - Expected    2093056.0, actual 2093056 (1.00x)
-Testing collisions (low   8-bit) - Expected    2096896.0, actual 2096896 (1.00x)
+Testing collisions (high 32-bit) - Expected        511.9, actual    512 (1.00x) (1)
+Testing collisions (high 24-36 bits) - Worst is 34 bits: 142/127 (1.11x)
+Testing collisions (low  32-bit) - Expected        511.9, actual    497 (0.97x)
+Testing collisions (low  24-36 bits) - Worst is 34 bits: 134/127 (1.05x)
+Testing distribution - Worst bias is the 18-bit window at bit  9 - 0.062%
 
 Testing bit 31
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected        512.0, actual    492 (0.96x)
-Testing collisions (high 24-36 bits) - Worst is 31 bits: 1061/1023 (1.04x)
-Testing collisions (high 12-bit) - Expected    2093056.0, actual 2093056 (1.00x)
-Testing collisions (high  8-bit) - Expected    2096896.0, actual 2096896 (1.00x)
-Testing collisions (low  32-bit) - Expected        512.0, actual    520 (1.02x) (9)
-Testing collisions (low  24-36 bits) - Worst is 36 bits: 42/31 (1.31x)
-Testing collisions (low  12-bit) - Expected    2093056.0, actual 2093056 (1.00x)
-Testing collisions (low   8-bit) - Expected    2096896.0, actual 2096896 (1.00x)
+Testing collisions (high 32-bit) - Expected        511.9, actual    475 (0.93x)
+Testing collisions (high 24-36 bits) - Worst is 36 bits: 38/31 (1.19x)
+Testing collisions (low  32-bit) - Expected        511.9, actual    523 (1.02x) (12)
+Testing collisions (low  24-36 bits) - Worst is 34 bits: 146/127 (1.14x)
+Testing distribution - Worst bias is the 18-bit window at bit 48 - 0.071%
 
 Testing bit 32
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected        512.0, actual    512 (1.00x) (1)
-Testing collisions (high 24-36 bits) - Worst is 35 bits: 67/63 (1.05x)
-Testing collisions (high 12-bit) - Expected    2093056.0, actual 2093056 (1.00x)
-Testing collisions (high  8-bit) - Expected    2096896.0, actual 2096896 (1.00x)
-Testing collisions (low  32-bit) - Expected        512.0, actual    556 (1.09x) (45)
-Testing collisions (low  24-36 bits) - Worst is 36 bits: 37/31 (1.16x)
-Testing collisions (low  12-bit) - Expected    2093056.0, actual 2093056 (1.00x)
-Testing collisions (low   8-bit) - Expected    2096896.0, actual 2096896 (1.00x)
+Testing collisions (high 32-bit) - Expected        511.9, actual    485 (0.95x)
+Testing collisions (high 24-36 bits) - Worst is 36 bits: 35/31 (1.09x)
+Testing collisions (low  32-bit) - Expected        511.9, actual    568 (1.11x) (57)
+Testing collisions (low  24-36 bits) - Worst is 36 bits: 39/31 (1.22x)
+Testing distribution - Worst bias is the 18-bit window at bit  8 - 0.068%
 
 Testing bit 33
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected        512.0, actual    505 (0.99x) (-6)
-Testing collisions (high 24-36 bits) - Worst is 28 bits: 8332/8191 (1.02x)
-Testing collisions (high 12-bit) - Expected    2093056.0, actual 2093056 (1.00x)
-Testing collisions (high  8-bit) - Expected    2096896.0, actual 2096896 (1.00x)
-Testing collisions (low  32-bit) - Expected        512.0, actual    489 (0.96x)
-Testing collisions (low  24-36 bits) - Worst is 35 bits: 65/63 (1.02x)
-Testing collisions (low  12-bit) - Expected    2093056.0, actual 2093056 (1.00x)
-Testing collisions (low   8-bit) - Expected    2096896.0, actual 2096896 (1.00x)
+Testing collisions (high 32-bit) - Expected        511.9, actual    537 (1.05x) (26)
+Testing collisions (high 24-36 bits) - Worst is 32 bits: 537/511 (1.05x)
+Testing collisions (low  32-bit) - Expected        511.9, actual    556 (1.09x) (45)
+Testing collisions (low  24-36 bits) - Worst is 34 bits: 145/127 (1.13x)
+Testing distribution - Worst bias is the 18-bit window at bit 55 - 0.080%
 
 Testing bit 34
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected        512.0, actual    518 (1.01x) (7)
-Testing collisions (high 24-36 bits) - Worst is 31 bits: 1067/1023 (1.04x)
-Testing collisions (high 12-bit) - Expected    2093056.0, actual 2093056 (1.00x)
-Testing collisions (high  8-bit) - Expected    2096896.0, actual 2096896 (1.00x)
-Testing collisions (low  32-bit) - Expected        512.0, actual    485 (0.95x)
-Testing collisions (low  24-36 bits) - Worst is 36 bits: 34/31 (1.06x)
-Testing collisions (low  12-bit) - Expected    2093056.0, actual 2093056 (1.00x)
-Testing collisions (low   8-bit) - Expected    2096896.0, actual 2096896 (1.00x)
+Testing collisions (high 32-bit) - Expected        511.9, actual    498 (0.97x)
+Testing collisions (high 24-36 bits) - Worst is 36 bits: 38/31 (1.19x)
+Testing collisions (low  32-bit) - Expected        511.9, actual    514 (1.00x) (3)
+Testing collisions (low  24-36 bits) - Worst is 36 bits: 45/31 (1.41x)
+Testing distribution - Worst bias is the 18-bit window at bit 22 - 0.065%
 
 Testing bit 35
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected        512.0, actual    502 (0.98x) (-9)
-Testing collisions (high 24-36 bits) - Worst is 31 bits: 1031/1023 (1.01x)
-Testing collisions (high 12-bit) - Expected    2093056.0, actual 2093056 (1.00x)
-Testing collisions (high  8-bit) - Expected    2096896.0, actual 2096896 (1.00x)
-Testing collisions (low  32-bit) - Expected        512.0, actual    528 (1.03x) (17)
-Testing collisions (low  24-36 bits) - Worst is 36 bits: 45/31 (1.41x)
-Testing collisions (low  12-bit) - Expected    2093056.0, actual 2093056 (1.00x)
-Testing collisions (low   8-bit) - Expected    2096896.0, actual 2096896 (1.00x)
+Testing collisions (high 32-bit) - Expected        511.9, actual    514 (1.00x) (3)
+Testing collisions (high 24-36 bits) - Worst is 36 bits: 34/31 (1.06x)
+Testing collisions (low  32-bit) - Expected        511.9, actual    521 (1.02x) (10)
+Testing collisions (low  24-36 bits) - Worst is 36 bits: 44/31 (1.38x)
+Testing distribution - Worst bias is the 18-bit window at bit 28 - 0.081%
 
 Testing bit 36
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected        512.0, actual    522 (1.02x) (11)
-Testing collisions (high 24-36 bits) - Worst is 34 bits: 143/127 (1.12x)
-Testing collisions (high 12-bit) - Expected    2093056.0, actual 2093056 (1.00x)
-Testing collisions (high  8-bit) - Expected    2096896.0, actual 2096896 (1.00x)
-Testing collisions (low  32-bit) - Expected        512.0, actual    500 (0.98x)
-Testing collisions (low  24-36 bits) - Worst is 27 bits: 16156/16383 (0.99x)
-Testing collisions (low  12-bit) - Expected    2093056.0, actual 2093056 (1.00x)
-Testing collisions (low   8-bit) - Expected    2096896.0, actual 2096896 (1.00x)
+Testing collisions (high 32-bit) - Expected        511.9, actual    575 (1.12x) (64)
+Testing collisions (high 24-36 bits) - Worst is 32 bits: 575/511 (1.12x)
+Testing collisions (low  32-bit) - Expected        511.9, actual    548 (1.07x) (37)
+Testing collisions (low  24-36 bits) - Worst is 32 bits: 548/511 (1.07x)
+Testing distribution - Worst bias is the 18-bit window at bit 28 - 0.080%
 
 Testing bit 37
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected        512.0, actual    562 (1.10x) (51)
-Testing collisions (high 24-36 bits) - Worst is 32 bits: 562/511 (1.10x)
-Testing collisions (high 12-bit) - Expected    2093056.0, actual 2093056 (1.00x)
-Testing collisions (high  8-bit) - Expected    2096896.0, actual 2096896 (1.00x)
-Testing collisions (low  32-bit) - Expected        512.0, actual    529 (1.03x) (18)
-Testing collisions (low  24-36 bits) - Worst is 36 bits: 35/31 (1.09x)
-Testing collisions (low  12-bit) - Expected    2093056.0, actual 2093056 (1.00x)
-Testing collisions (low   8-bit) - Expected    2096896.0, actual 2096896 (1.00x)
+Testing collisions (high 32-bit) - Expected        511.9, actual    553 (1.08x) (42)
+Testing collisions (high 24-36 bits) - Worst is 33 bits: 303/255 (1.18x)
+Testing collisions (low  32-bit) - Expected        511.9, actual    469 (0.92x)
+Testing collisions (low  24-36 bits) - Worst is 29 bits: 4183/4090 (1.02x)
+Testing distribution - Worst bias is the 18-bit window at bit 44 - 0.076%
 
 Testing bit 38
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected        512.0, actual    501 (0.98x)
-Testing collisions (high 24-36 bits) - Worst is 30 bits: 2049/2047 (1.00x)
-Testing collisions (high 12-bit) - Expected    2093056.0, actual 2093056 (1.00x)
-Testing collisions (high  8-bit) - Expected    2096896.0, actual 2096896 (1.00x)
-Testing collisions (low  32-bit) - Expected        512.0, actual    504 (0.98x) (-7)
-Testing collisions (low  24-36 bits) - Worst is 36 bits: 37/31 (1.16x)
-Testing collisions (low  12-bit) - Expected    2093056.0, actual 2093056 (1.00x)
-Testing collisions (low   8-bit) - Expected    2096896.0, actual 2096896 (1.00x)
+Testing collisions (high 32-bit) - Expected        511.9, actual    495 (0.97x)
+Testing collisions (high 24-36 bits) - Worst is 35 bits: 66/63 (1.03x)
+Testing collisions (low  32-bit) - Expected        511.9, actual    524 (1.02x) (13)
+Testing collisions (low  24-36 bits) - Worst is 36 bits: 35/31 (1.09x)
+Testing distribution - Worst bias is the 18-bit window at bit  7 - 0.067%
 
 Testing bit 39
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected        512.0, actual    473 (0.92x)
-Testing collisions (high 24-36 bits) - Worst is 29 bits: 4094/4095 (1.00x)
-Testing collisions (high 12-bit) - Expected    2093056.0, actual 2093056 (1.00x)
-Testing collisions (high  8-bit) - Expected    2096896.0, actual 2096896 (1.00x)
-Testing collisions (low  32-bit) - Expected        512.0, actual    503 (0.98x) (-8)
-Testing collisions (low  24-36 bits) - Worst is 36 bits: 38/31 (1.19x)
-Testing collisions (low  12-bit) - Expected    2093056.0, actual 2093056 (1.00x)
-Testing collisions (low   8-bit) - Expected    2096896.0, actual 2096896 (1.00x)
+Testing collisions (high 32-bit) - Expected        511.9, actual    480 (0.94x)
+Testing collisions (high 24-36 bits) - Worst is 24 bits: 125741/125777 (1.00x)
+Testing collisions (low  32-bit) - Expected        511.9, actual    542 (1.06x) (31)
+Testing collisions (low  24-36 bits) - Worst is 35 bits: 73/63 (1.14x)
+Testing distribution - Worst bias is the 17-bit window at bit  0 - 0.053%
 
 Testing bit 40
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected        512.0, actual    563 (1.10x) (52)
-Testing collisions (high 24-36 bits) - Worst is 35 bits: 83/63 (1.30x)
-Testing collisions (high 12-bit) - Expected    2093056.0, actual 2093056 (1.00x)
-Testing collisions (high  8-bit) - Expected    2096896.0, actual 2096896 (1.00x)
-Testing collisions (low  32-bit) - Expected        512.0, actual    537 (1.05x) (26)
-Testing collisions (low  24-36 bits) - Worst is 33 bits: 272/255 (1.06x)
-Testing collisions (low  12-bit) - Expected    2093056.0, actual 2093056 (1.00x)
-Testing collisions (low   8-bit) - Expected    2096896.0, actual 2096896 (1.00x)
+Testing collisions (high 32-bit) - Expected        511.9, actual    523 (1.02x) (12)
+Testing collisions (high 24-36 bits) - Worst is 35 bits: 67/63 (1.05x)
+Testing collisions (low  32-bit) - Expected        511.9, actual    523 (1.02x) (12)
+Testing collisions (low  24-36 bits) - Worst is 35 bits: 71/63 (1.11x)
+Testing distribution - Worst bias is the 18-bit window at bit 18 - 0.098%
 
 Testing bit 41
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected        512.0, actual    552 (1.08x) (41)
-Testing collisions (high 24-36 bits) - Worst is 35 bits: 82/63 (1.28x)
-Testing collisions (high 12-bit) - Expected    2093056.0, actual 2093056 (1.00x)
-Testing collisions (high  8-bit) - Expected    2096896.0, actual 2096896 (1.00x)
-Testing collisions (low  32-bit) - Expected        512.0, actual    529 (1.03x) (18)
-Testing collisions (low  24-36 bits) - Worst is 31 bits: 1073/1023 (1.05x)
-Testing collisions (low  12-bit) - Expected    2093056.0, actual 2093056 (1.00x)
-Testing collisions (low   8-bit) - Expected    2096896.0, actual 2096896 (1.00x)
+Testing collisions (high 32-bit) - Expected        511.9, actual    520 (1.02x) (9)
+Testing collisions (high 24-36 bits) - Worst is 36 bits: 34/31 (1.06x)
+Testing collisions (low  32-bit) - Expected        511.9, actual    519 (1.01x) (8)
+Testing collisions (low  24-36 bits) - Worst is 35 bits: 71/63 (1.11x)
+Testing distribution - Worst bias is the 18-bit window at bit 44 - 0.072%
 
 Testing bit 42
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected        512.0, actual    504 (0.98x) (-7)
-Testing collisions (high 24-36 bits) - Worst is 35 bits: 71/63 (1.11x)
-Testing collisions (high 12-bit) - Expected    2093056.0, actual 2093056 (1.00x)
-Testing collisions (high  8-bit) - Expected    2096896.0, actual 2096896 (1.00x)
-Testing collisions (low  32-bit) - Expected        512.0, actual    520 (1.02x) (9)
-Testing collisions (low  24-36 bits) - Worst is 32 bits: 520/511 (1.02x)
-Testing collisions (low  12-bit) - Expected    2093056.0, actual 2093056 (1.00x)
-Testing collisions (low   8-bit) - Expected    2096896.0, actual 2096896 (1.00x)
+Testing collisions (high 32-bit) - Expected        511.9, actual    503 (0.98x) (-8)
+Testing collisions (high 24-36 bits) - Worst is 36 bits: 40/31 (1.25x)
+Testing collisions (low  32-bit) - Expected        511.9, actual    531 (1.04x) (20)
+Testing collisions (low  24-36 bits) - Worst is 33 bits: 273/255 (1.07x)
+Testing distribution - Worst bias is the 18-bit window at bit  4 - 0.072%
 
 Testing bit 43
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected        512.0, actual    537 (1.05x) (26)
-Testing collisions (high 24-36 bits) - Worst is 36 bits: 39/31 (1.22x)
-Testing collisions (high 12-bit) - Expected    2093056.0, actual 2093056 (1.00x)
-Testing collisions (high  8-bit) - Expected    2096896.0, actual 2096896 (1.00x)
-Testing collisions (low  32-bit) - Expected        512.0, actual    547 (1.07x) (36)
-Testing collisions (low  24-36 bits) - Worst is 33 bits: 286/255 (1.12x)
-Testing collisions (low  12-bit) - Expected    2093056.0, actual 2093056 (1.00x)
-Testing collisions (low   8-bit) - Expected    2096896.0, actual 2096896 (1.00x)
+Testing collisions (high 32-bit) - Expected        511.9, actual    546 (1.07x) (35)
+Testing collisions (high 24-36 bits) - Worst is 33 bits: 287/255 (1.12x)
+Testing collisions (low  32-bit) - Expected        511.9, actual    480 (0.94x)
+Testing collisions (low  24-36 bits) - Worst is 34 bits: 133/127 (1.04x)
+Testing distribution - Worst bias is the 18-bit window at bit 43 - 0.073%
 
 Testing bit 44
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected        512.0, actual    471 (0.92x)
-Testing collisions (high 24-36 bits) - Worst is 36 bits: 39/31 (1.22x)
-Testing collisions (high 12-bit) - Expected    2093056.0, actual 2093056 (1.00x)
-Testing collisions (high  8-bit) - Expected    2096896.0, actual 2096896 (1.00x)
-Testing collisions (low  32-bit) - Expected        512.0, actual    560 (1.09x) (49)
-Testing collisions (low  24-36 bits) - Worst is 36 bits: 38/31 (1.19x)
-Testing collisions (low  12-bit) - Expected    2093056.0, actual 2093056 (1.00x)
-Testing collisions (low   8-bit) - Expected    2096896.0, actual 2096896 (1.00x)
+Testing collisions (high 32-bit) - Expected        511.9, actual    530 (1.04x) (19)
+Testing collisions (high 24-36 bits) - Worst is 36 bits: 40/31 (1.25x)
+Testing collisions (low  32-bit) - Expected        511.9, actual    510 (1.00x) (-1)
+Testing collisions (low  24-36 bits) - Worst is 27 bits: 16377/16298 (1.00x)
+Testing distribution - Worst bias is the 18-bit window at bit 27 - 0.057%
 
 Testing bit 45
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected        512.0, actual    509 (0.99x) (-2)
-Testing collisions (high 24-36 bits) - Worst is 35 bits: 72/63 (1.13x)
-Testing collisions (high 12-bit) - Expected    2093056.0, actual 2093056 (1.00x)
-Testing collisions (high  8-bit) - Expected    2096896.0, actual 2096896 (1.00x)
-Testing collisions (low  32-bit) - Expected        512.0, actual    501 (0.98x)
-Testing collisions (low  24-36 bits) - Worst is 27 bits: 16256/16383 (0.99x)
-Testing collisions (low  12-bit) - Expected    2093056.0, actual 2093056 (1.00x)
-Testing collisions (low   8-bit) - Expected    2096896.0, actual 2096896 (1.00x)
+Testing collisions (high 32-bit) - Expected        511.9, actual    510 (1.00x) (-1)
+Testing collisions (high 24-36 bits) - Worst is 26 bits: 32880/32429 (1.01x)
+Testing collisions (low  32-bit) - Expected        511.9, actual    525 (1.03x) (14)
+Testing collisions (low  24-36 bits) - Worst is 36 bits: 39/31 (1.22x)
+Testing distribution - Worst bias is the 18-bit window at bit 35 - 0.076%
 
 Testing bit 46
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected        512.0, actual    510 (1.00x) (-1)
-Testing collisions (high 24-36 bits) - Worst is 35 bits: 69/63 (1.08x)
-Testing collisions (high 12-bit) - Expected    2093056.0, actual 2093056 (1.00x)
-Testing collisions (high  8-bit) - Expected    2096896.0, actual 2096896 (1.00x)
-Testing collisions (low  32-bit) - Expected        512.0, actual    486 (0.95x)
-Testing collisions (low  24-36 bits) - Worst is 30 bits: 2043/2047 (1.00x)
-Testing collisions (low  12-bit) - Expected    2093056.0, actual 2093056 (1.00x)
-Testing collisions (low   8-bit) - Expected    2096896.0, actual 2096896 (1.00x)
+Testing collisions (high 32-bit) - Expected        511.9, actual    513 (1.00x) (2)
+Testing collisions (high 24-36 bits) - Worst is 36 bits: 34/31 (1.06x)
+Testing collisions (low  32-bit) - Expected        511.9, actual    573 (1.12x) (62)
+Testing collisions (low  24-36 bits) - Worst is 36 bits: 40/31 (1.25x)
+Testing distribution - Worst bias is the 17-bit window at bit 53 - 0.061%
 
 Testing bit 47
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected        512.0, actual    541 (1.06x) (30)
-Testing collisions (high 24-36 bits) - Worst is 34 bits: 142/127 (1.11x)
-Testing collisions (high 12-bit) - Expected    2093056.0, actual 2093056 (1.00x)
-Testing collisions (high  8-bit) - Expected    2096896.0, actual 2096896 (1.00x)
-Testing collisions (low  32-bit) - Expected        512.0, actual    498 (0.97x)
-Testing collisions (low  24-36 bits) - Worst is 29 bits: 4094/4095 (1.00x)
-Testing collisions (low  12-bit) - Expected    2093056.0, actual 2093056 (1.00x)
-Testing collisions (low   8-bit) - Expected    2096896.0, actual 2096896 (1.00x)
+Testing collisions (high 32-bit) - Expected        511.9, actual    503 (0.98x) (-8)
+Testing collisions (high 24-36 bits) - Worst is 30 bits: 2078/2046 (1.02x)
+Testing collisions (low  32-bit) - Expected        511.9, actual    475 (0.93x)
+Testing collisions (low  24-36 bits) - Worst is 24 bits: 125854/125777 (1.00x)
+Testing distribution - Worst bias is the 18-bit window at bit  7 - 0.077%
 
 Testing bit 48
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected        512.0, actual    550 (1.07x) (39)
-Testing collisions (high 24-36 bits) - Worst is 36 bits: 55/31 (1.72x)
-Testing collisions (high 12-bit) - Expected    2093056.0, actual 2093056 (1.00x)
-Testing collisions (high  8-bit) - Expected    2096896.0, actual 2096896 (1.00x)
-Testing collisions (low  32-bit) - Expected        512.0, actual    527 (1.03x) (16)
-Testing collisions (low  24-36 bits) - Worst is 34 bits: 149/127 (1.16x)
-Testing collisions (low  12-bit) - Expected    2093056.0, actual 2093056 (1.00x)
-Testing collisions (low   8-bit) - Expected    2096896.0, actual 2096896 (1.00x)
+Testing collisions (high 32-bit) - Expected        511.9, actual    511 (1.00x)
+Testing collisions (high 24-36 bits) - Worst is 35 bits: 67/63 (1.05x)
+Testing collisions (low  32-bit) - Expected        511.9, actual    487 (0.95x)
+Testing collisions (low  24-36 bits) - Worst is 35 bits: 65/63 (1.02x)
+Testing distribution - Worst bias is the 18-bit window at bit 57 - 0.075%
 
 Testing bit 49
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected        512.0, actual    523 (1.02x) (12)
-Testing collisions (high 24-36 bits) - Worst is 35 bits: 76/63 (1.19x)
-Testing collisions (high 12-bit) - Expected    2093056.0, actual 2093056 (1.00x)
-Testing collisions (high  8-bit) - Expected    2096896.0, actual 2096896 (1.00x)
-Testing collisions (low  32-bit) - Expected        512.0, actual    538 (1.05x) (27)
-Testing collisions (low  24-36 bits) - Worst is 36 bits: 40/31 (1.25x)
-Testing collisions (low  12-bit) - Expected    2093056.0, actual 2093056 (1.00x)
-Testing collisions (low   8-bit) - Expected    2096896.0, actual 2096896 (1.00x)
+Testing collisions (high 32-bit) - Expected        511.9, actual    530 (1.04x) (19)
+Testing collisions (high 24-36 bits) - Worst is 36 bits: 34/31 (1.06x)
+Testing collisions (low  32-bit) - Expected        511.9, actual    530 (1.04x) (19)
+Testing collisions (low  24-36 bits) - Worst is 30 bits: 2125/2046 (1.04x)
+Testing distribution - Worst bias is the 18-bit window at bit 55 - 0.071%
 
 Testing bit 50
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected        512.0, actual    477 (0.93x)
-Testing collisions (high 24-36 bits) - Worst is 34 bits: 132/127 (1.03x)
-Testing collisions (high 12-bit) - Expected    2093056.0, actual 2093056 (1.00x)
-Testing collisions (high  8-bit) - Expected    2096896.0, actual 2096896 (1.00x)
-Testing collisions (low  32-bit) - Expected        512.0, actual    498 (0.97x)
-Testing collisions (low  24-36 bits) - Worst is 36 bits: 37/31 (1.16x)
-Testing collisions (low  12-bit) - Expected    2093056.0, actual 2093056 (1.00x)
-Testing collisions (low   8-bit) - Expected    2096896.0, actual 2096896 (1.00x)
+Testing collisions (high 32-bit) - Expected        511.9, actual    548 (1.07x) (37)
+Testing collisions (high 24-36 bits) - Worst is 36 bits: 37/31 (1.16x)
+Testing collisions (low  32-bit) - Expected        511.9, actual    560 (1.09x) (49)
+Testing collisions (low  24-36 bits) - Worst is 34 bits: 144/127 (1.13x)
+Testing distribution - Worst bias is the 18-bit window at bit  7 - 0.123%
 
 Testing bit 51
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected        512.0, actual    519 (1.01x) (8)
-Testing collisions (high 24-36 bits) - Worst is 36 bits: 34/31 (1.06x)
-Testing collisions (high 12-bit) - Expected    2093056.0, actual 2093056 (1.00x)
-Testing collisions (high  8-bit) - Expected    2096896.0, actual 2096896 (1.00x)
-Testing collisions (low  32-bit) - Expected        512.0, actual    533 (1.04x) (22)
-Testing collisions (low  24-36 bits) - Worst is 32 bits: 533/511 (1.04x)
-Testing collisions (low  12-bit) - Expected    2093056.0, actual 2093056 (1.00x)
-Testing collisions (low   8-bit) - Expected    2096896.0, actual 2096896 (1.00x)
+Testing collisions (high 32-bit) - Expected        511.9, actual    533 (1.04x) (22)
+Testing collisions (high 24-36 bits) - Worst is 35 bits: 74/63 (1.16x)
+Testing collisions (low  32-bit) - Expected        511.9, actual    520 (1.02x) (9)
+Testing collisions (low  24-36 bits) - Worst is 29 bits: 4156/4090 (1.02x)
+Testing distribution - Worst bias is the 18-bit window at bit 59 - 0.070%
 
 Testing bit 52
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected        512.0, actual    562 (1.10x) (51)
-Testing collisions (high 24-36 bits) - Worst is 33 bits: 293/255 (1.14x)
-Testing collisions (high 12-bit) - Expected    2093056.0, actual 2093056 (1.00x)
-Testing collisions (high  8-bit) - Expected    2096896.0, actual 2096896 (1.00x)
-Testing collisions (low  32-bit) - Expected        512.0, actual    545 (1.06x) (34)
-Testing collisions (low  24-36 bits) - Worst is 33 bits: 288/255 (1.13x)
-Testing collisions (low  12-bit) - Expected    2093056.0, actual 2093056 (1.00x)
-Testing collisions (low   8-bit) - Expected    2096896.0, actual 2096896 (1.00x)
+Testing collisions (high 32-bit) - Expected        511.9, actual    489 (0.96x)
+Testing collisions (high 24-36 bits) - Worst is 30 bits: 2066/2046 (1.01x)
+Testing collisions (low  32-bit) - Expected        511.9, actual    503 (0.98x) (-8)
+Testing collisions (low  24-36 bits) - Worst is 26 bits: 32529/32429 (1.00x)
+Testing distribution - Worst bias is the 18-bit window at bit 42 - 0.084%
 
 Testing bit 53
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected        512.0, actual    499 (0.97x)
-Testing collisions (high 24-36 bits) - Worst is 33 bits: 262/255 (1.02x)
-Testing collisions (high 12-bit) - Expected    2093056.0, actual 2093056 (1.00x)
-Testing collisions (high  8-bit) - Expected    2096896.0, actual 2096896 (1.00x)
-Testing collisions (low  32-bit) - Expected        512.0, actual    493 (0.96x)
-Testing collisions (low  24-36 bits) - Worst is 35 bits: 67/63 (1.05x)
-Testing collisions (low  12-bit) - Expected    2093056.0, actual 2093056 (1.00x)
-Testing collisions (low   8-bit) - Expected    2096896.0, actual 2096896 (1.00x)
+Testing collisions (high 32-bit) - Expected        511.9, actual    527 (1.03x) (16)
+Testing collisions (high 24-36 bits) - Worst is 30 bits: 2145/2046 (1.05x)
+Testing collisions (low  32-bit) - Expected        511.9, actual    504 (0.98x) (-7)
+Testing collisions (low  24-36 bits) - Worst is 26 bits: 32595/32429 (1.01x)
+Testing distribution - Worst bias is the 18-bit window at bit 46 - 0.084%
 
 Testing bit 54
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected        512.0, actual    534 (1.04x) (23)
-Testing collisions (high 24-36 bits) - Worst is 34 bits: 134/127 (1.05x)
-Testing collisions (high 12-bit) - Expected    2093056.0, actual 2093056 (1.00x)
-Testing collisions (high  8-bit) - Expected    2096896.0, actual 2096896 (1.00x)
-Testing collisions (low  32-bit) - Expected        512.0, actual    479 (0.94x)
-Testing collisions (low  24-36 bits) - Worst is 27 bits: 16332/16383 (1.00x)
-Testing collisions (low  12-bit) - Expected    2093056.0, actual 2093056 (1.00x)
-Testing collisions (low   8-bit) - Expected    2096896.0, actual 2096896 (1.00x)
+Testing collisions (high 32-bit) - Expected        511.9, actual    515 (1.01x) (4)
+Testing collisions (high 24-36 bits) - Worst is 35 bits: 71/63 (1.11x)
+Testing collisions (low  32-bit) - Expected        511.9, actual    540 (1.05x) (29)
+Testing collisions (low  24-36 bits) - Worst is 34 bits: 153/127 (1.20x)
+Testing distribution - Worst bias is the 18-bit window at bit 18 - 0.089%
 
 Testing bit 55
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected        512.0, actual    521 (1.02x) (10)
-Testing collisions (high 24-36 bits) - Worst is 30 bits: 2093/2047 (1.02x)
-Testing collisions (high 12-bit) - Expected    2093056.0, actual 2093056 (1.00x)
-Testing collisions (high  8-bit) - Expected    2096896.0, actual 2096896 (1.00x)
-Testing collisions (low  32-bit) - Expected        512.0, actual    522 (1.02x) (11)
-Testing collisions (low  24-36 bits) - Worst is 36 bits: 40/31 (1.25x)
-Testing collisions (low  12-bit) - Expected    2093056.0, actual 2093056 (1.00x)
-Testing collisions (low   8-bit) - Expected    2096896.0, actual 2096896 (1.00x)
+Testing collisions (high 32-bit) - Expected        511.9, actual    551 (1.08x) (40)
+Testing collisions (high 24-36 bits) - Worst is 35 bits: 77/63 (1.20x)
+Testing collisions (low  32-bit) - Expected        511.9, actual    529 (1.03x) (18)
+Testing collisions (low  24-36 bits) - Worst is 32 bits: 529/511 (1.03x)
+Testing distribution - Worst bias is the 18-bit window at bit 24 - 0.118%
 
 Testing bit 56
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected        512.0, actual    482 (0.94x)
-Testing collisions (high 24-36 bits) - Worst is 28 bits: 8273/8191 (1.01x)
-Testing collisions (high 12-bit) - Expected    2093056.0, actual 2093056 (1.00x)
-Testing collisions (high  8-bit) - Expected    2096896.0, actual 2096896 (1.00x)
-Testing collisions (low  32-bit) - Expected        512.0, actual    556 (1.09x) (45)
-Testing collisions (low  24-36 bits) - Worst is 36 bits: 41/31 (1.28x)
-Testing collisions (low  12-bit) - Expected    2093056.0, actual 2093056 (1.00x)
-Testing collisions (low   8-bit) - Expected    2096896.0, actual 2096896 (1.00x)
+Testing collisions (high 32-bit) - Expected        511.9, actual    513 (1.00x) (2)
+Testing collisions (high 24-36 bits) - Worst is 36 bits: 42/31 (1.31x)
+Testing collisions (low  32-bit) - Expected        511.9, actual    489 (0.96x)
+Testing collisions (low  24-36 bits) - Worst is 30 bits: 2079/2046 (1.02x)
+Testing distribution - Worst bias is the 18-bit window at bit 58 - 0.104%
 
 Testing bit 57
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected        512.0, actual    474 (0.93x)
-Testing collisions (high 24-36 bits) - Worst is 35 bits: 64/63 (1.00x)
-Testing collisions (high 12-bit) - Expected    2093056.0, actual 2093056 (1.00x)
-Testing collisions (high  8-bit) - Expected    2096896.0, actual 2096896 (1.00x)
-Testing collisions (low  32-bit) - Expected        512.0, actual    531 (1.04x) (20)
-Testing collisions (low  24-36 bits) - Worst is 36 bits: 37/31 (1.16x)
-Testing collisions (low  12-bit) - Expected    2093056.0, actual 2093056 (1.00x)
-Testing collisions (low   8-bit) - Expected    2096896.0, actual 2096896 (1.00x)
+Testing collisions (high 32-bit) - Expected        511.9, actual    516 (1.01x) (5)
+Testing collisions (high 24-36 bits) - Worst is 36 bits: 44/31 (1.38x)
+Testing collisions (low  32-bit) - Expected        511.9, actual    526 (1.03x) (15)
+Testing collisions (low  24-36 bits) - Worst is 34 bits: 146/127 (1.14x)
+Testing distribution - Worst bias is the 18-bit window at bit 24 - 0.101%
 
 Testing bit 58
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected        512.0, actual    488 (0.95x)
-Testing collisions (high 24-36 bits) - Worst is 36 bits: 39/31 (1.22x)
-Testing collisions (high 12-bit) - Expected    2093056.0, actual 2093056 (1.00x)
-Testing collisions (high  8-bit) - Expected    2096896.0, actual 2096896 (1.00x)
-Testing collisions (low  32-bit) - Expected        512.0, actual    543 (1.06x) (32)
-Testing collisions (low  24-36 bits) - Worst is 32 bits: 543/511 (1.06x)
-Testing collisions (low  12-bit) - Expected    2093056.0, actual 2093056 (1.00x)
-Testing collisions (low   8-bit) - Expected    2096896.0, actual 2096896 (1.00x)
+Testing collisions (high 32-bit) - Expected        511.9, actual    562 (1.10x) (51)
+Testing collisions (high 24-36 bits) - Worst is 33 bits: 290/255 (1.13x)
+Testing collisions (low  32-bit) - Expected        511.9, actual    549 (1.07x) (38)
+Testing collisions (low  24-36 bits) - Worst is 32 bits: 549/511 (1.07x)
+Testing distribution - Worst bias is the 18-bit window at bit  3 - 0.080%
 
 Testing bit 59
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected        512.0, actual    528 (1.03x) (17)
-Testing collisions (high 24-36 bits) - Worst is 36 bits: 40/31 (1.25x)
-Testing collisions (high 12-bit) - Expected    2093056.0, actual 2093056 (1.00x)
-Testing collisions (high  8-bit) - Expected    2096896.0, actual 2096896 (1.00x)
-Testing collisions (low  32-bit) - Expected        512.0, actual    541 (1.06x) (30)
-Testing collisions (low  24-36 bits) - Worst is 36 bits: 36/31 (1.13x)
-Testing collisions (low  12-bit) - Expected    2093056.0, actual 2093056 (1.00x)
-Testing collisions (low   8-bit) - Expected    2096896.0, actual 2096896 (1.00x)
+Testing collisions (high 32-bit) - Expected        511.9, actual    501 (0.98x)
+Testing collisions (high 24-36 bits) - Worst is 34 bits: 133/127 (1.04x)
+Testing collisions (low  32-bit) - Expected        511.9, actual    516 (1.01x) (5)
+Testing collisions (low  24-36 bits) - Worst is 34 bits: 143/127 (1.12x)
+Testing distribution - Worst bias is the 18-bit window at bit 30 - 0.076%
 
 Testing bit 60
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected        512.0, actual    528 (1.03x) (17)
-Testing collisions (high 24-36 bits) - Worst is 34 bits: 147/127 (1.15x)
-Testing collisions (high 12-bit) - Expected    2093056.0, actual 2093056 (1.00x)
-Testing collisions (high  8-bit) - Expected    2096896.0, actual 2096896 (1.00x)
-Testing collisions (low  32-bit) - Expected        512.0, actual    507 (0.99x) (-4)
-Testing collisions (low  24-36 bits) - Worst is 32 bits: 507/511 (0.99x)
-Testing collisions (low  12-bit) - Expected    2093056.0, actual 2093056 (1.00x)
-Testing collisions (low   8-bit) - Expected    2096896.0, actual 2096896 (1.00x)
+Testing collisions (high 32-bit) - Expected        511.9, actual    509 (0.99x) (-2)
+Testing collisions (high 24-36 bits) - Worst is 34 bits: 129/127 (1.01x)
+Testing collisions (low  32-bit) - Expected        511.9, actual    537 (1.05x) (26)
+Testing collisions (low  24-36 bits) - Worst is 34 bits: 142/127 (1.11x)
+Testing distribution - Worst bias is the 18-bit window at bit 41 - 0.104%
 
 Testing bit 61
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected        512.0, actual    491 (0.96x)
-Testing collisions (high 24-36 bits) - Worst is 34 bits: 135/127 (1.05x)
-Testing collisions (high 12-bit) - Expected    2093056.0, actual 2093056 (1.00x)
-Testing collisions (high  8-bit) - Expected    2096896.0, actual 2096896 (1.00x)
-Testing collisions (low  32-bit) - Expected        512.0, actual    529 (1.03x) (18)
-Testing collisions (low  24-36 bits) - Worst is 33 bits: 274/255 (1.07x)
-Testing collisions (low  12-bit) - Expected    2093056.0, actual 2093056 (1.00x)
-Testing collisions (low   8-bit) - Expected    2096896.0, actual 2096896 (1.00x)
+Testing collisions (high 32-bit) - Expected        511.9, actual    502 (0.98x) (-9)
+Testing collisions (high 24-36 bits) - Worst is 33 bits: 263/255 (1.03x)
+Testing collisions (low  32-bit) - Expected        511.9, actual    525 (1.03x) (14)
+Testing collisions (low  24-36 bits) - Worst is 35 bits: 66/63 (1.03x)
+Testing distribution - Worst bias is the 18-bit window at bit 60 - 0.089%
 
 Testing bit 62
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected        512.0, actual    518 (1.01x) (7)
-Testing collisions (high 24-36 bits) - Worst is 36 bits: 35/31 (1.09x)
-Testing collisions (high 12-bit) - Expected    2093056.0, actual 2093056 (1.00x)
-Testing collisions (high  8-bit) - Expected    2096896.0, actual 2096896 (1.00x)
-Testing collisions (low  32-bit) - Expected        512.0, actual    504 (0.98x) (-7)
-Testing collisions (low  24-36 bits) - Worst is 33 bits: 263/255 (1.03x)
-Testing collisions (low  12-bit) - Expected    2093056.0, actual 2093056 (1.00x)
-Testing collisions (low   8-bit) - Expected    2096896.0, actual 2096896 (1.00x)
+Testing collisions (high 32-bit) - Expected        511.9, actual    541 (1.06x) (30)
+Testing collisions (high 24-36 bits) - Worst is 32 bits: 541/511 (1.06x)
+Testing collisions (low  32-bit) - Expected        511.9, actual    502 (0.98x) (-9)
+Testing collisions (low  24-36 bits) - Worst is 35 bits: 73/63 (1.14x)
+Testing distribution - Worst bias is the 18-bit window at bit  4 - 0.057%
 
 Testing bit 63
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected        512.0, actual    501 (0.98x)
-Testing collisions (high 24-36 bits) - Worst is 35 bits: 64/63 (1.00x)
-Testing collisions (high 12-bit) - Expected    2093056.0, actual 2093056 (1.00x)
-Testing collisions (high  8-bit) - Expected    2096896.0, actual 2096896 (1.00x)
-Testing collisions (low  32-bit) - Expected        512.0, actual    540 (1.05x) (29)
-Testing collisions (low  24-36 bits) - Worst is 32 bits: 540/511 (1.05x)
-Testing collisions (low  12-bit) - Expected    2093056.0, actual 2093056 (1.00x)
-Testing collisions (low   8-bit) - Expected    2096896.0, actual 2096896 (1.00x)
+Testing collisions (high 32-bit) - Expected        511.9, actual    479 (0.94x)
+Testing collisions (high 24-36 bits) - Worst is 36 bits: 37/31 (1.16x)
+Testing collisions (low  32-bit) - Expected        511.9, actual    562 (1.10x) (51)
+Testing collisions (low  24-36 bits) - Worst is 36 bits: 37/31 (1.16x)
+Testing distribution - Worst bias is the 18-bit window at bit 50 - 0.061%
 
 
 [[[ MomentChi2 Tests ]]]
 
-Analyze hashes produced from a serie of linearly increasing numbers of 32-bit, using a step of 3 ...
-Target values to approximate : 38918200.000000 - 410450.000000
-Popcount 1 stats : 38919009.002476 - 410418.684847
-Popcount 0 stats : 38918228.154163 - 410448.629383
-MomentChi2 for bits 1 :  0.797308
-MomentChi2 for bits 0 :  0.000965597
+Analyze hashes produced from a serie of linearly increasing numbers of 32-bit, using a step of 2 ...
+Target values to approximate : 38918200.000000 - 273633.333333
+4 threads starting...  done
+Popcount 1 stats : 38919070.880649 - 273658.516930
+Popcount 0 stats : 38919194.839021 - 273657.339256
+MomentChi2 for bits 1 :   1.38579
+MomentChi2 for bits 0 :   1.80837
 
 Derivative stats (transition from 2 consecutive values) :
-Popcount 1 stats : 38918663.472812 - 410471.885420
-Popcount 0 stats : 38919044.952108 - 410462.633874
-MomentChi2 for deriv b1 :  0.261666
-MomentChi2 for deriv b0 :  0.869696
+Popcount 1 stats : 38918610.739435 - 273628.413070
+Popcount 0 stats : 38919023.148389 - 273649.013652
+MomentChi2 for deriv b1 :  0.308275
+MomentChi2 for deriv b0 :   1.23807
 
-  Great !!
+  Great
 
 
 [[[ Prng Tests ]]]
 
 Generating 33554432 random numbers :
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected     131072.0, actual 131073 (1.00x) (2)
-Testing collisions (high 28-44 bits) - Worst is 41 bits: 309/255 (1.21x)
-Testing collisions (high 12-bit) - Expected   33550336.0, actual 33550336 (1.00x)
-Testing collisions (high  8-bit) - Expected   33554176.0, actual 33554176 (1.00x)
-Testing collisions (low  32-bit) - Expected     131072.0, actual 131184 (1.00x) (113)
-Testing collisions (low  28-44 bits) - Worst is 42 bits: 138/127 (1.08x)
-Testing collisions (low  12-bit) - Expected   33550336.0, actual 33550336 (1.00x)
-Testing collisions (low   8-bit) - Expected   33554176.0, actual 33554176 (1.00x)
+Testing collisions (high 32-bit) - Expected     130731.3, actual 130656 (1.00x) (-75)
+Testing collisions (high 28-44 bits) - Worst is 43 bits: 66/63 (1.03x)
+Testing collisions (low  32-bit) - Expected     130731.3, actual 130961 (1.00x) (230)
+Testing collisions (low  28-44 bits) - Worst is 37 bits: 4145/4095 (1.01x)
+
+[[[ BadSeeds Tests ]]]
+
+Testing 0 internal secrets:
+0x0 PASS
 
 
 Input vcode 0x00000001, Output vcode 0x00000001, Result vcode 0x00000001
-Verification value is 0x00000001 - Testing took 646.187375 seconds
+Verification value is 0x00000001 - Testing took 594.176606 seconds
 -------------------------------------------------------------------------------


### PR DESCRIPTION
Pulling patch into 0.7 release branch

This change adds a test which probes for issues with sparse inputs on the fast path.

This fixes #163 in multiple ways. Each of the improvements have been tested individually and in various combinations with weakened versions of other parts of the algorithm to insure they work as intended and provide a benefit.