### PR TITLE
Update once_cell to remove "unstable" feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,7 +83,7 @@ getrandom = { version = "0.2.7", optional = true }
 zerocopy = { version = "0.7.14", default-features = false, features = ["simd"] }
 
 [target.'cfg(not(all(target_arch = "arm", target_os = "none")))'.dependencies]
-once_cell = { version = "1.13.1", default-features = false, features = ["unstable", "alloc"] }
+once_cell = { version = "1.18.0", default-features = false, features = ["alloc"] }
 
 [dev-dependencies]
 no-panic = "0.1.10"


### PR DESCRIPTION
According to [once_cell 1.18.0](https://github.com/matklad/once_cell/blob/v1.18.0/Cargo.toml#L55), the "unstable" feature is no longer used. This patch updates the crate and removes the feature so we do not accidentally enable any other unstable `once_cell` features in the future.