### PR TITLE
Update zerocopy version to 0.7.31

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,7 +84,7 @@ serde = { version = "1.0.117", optional = true }
 cfg-if = "1.0"
 atomic-polyfill = { version="1.0.1", optional=true}
 getrandom = { version = "0.2.7", optional = true }
-zerocopy = { version = "0.7.20", default-features = false, features = ["simd"] }
+zerocopy = { version = "0.7.31", default-features = false, features = ["simd"] }
 
 [target.'cfg(not(all(target_arch = "arm", target_os = "none")))'.dependencies]
 once_cell = { version = "1.18.0", default-features = false, features = ["alloc"] }


### PR DESCRIPTION
There is a security vulnerability in older versions of the crate: https://rustsec.org/advisories/RUSTSEC-2023-0074

Updating the version will mitigate this.