### PR TITLE
Update GitHub Actions CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -6,191 +6,129 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Install latest stable
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
             toolchain: stable
             components: clippy
       - name: check nostd
-        uses: actions-rs/cargo@v1
-        with:
-          command: check
-          args: --no-default-features
+        run: cargo check --no-default-features
       - name: test nostd
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --no-default-features
+        run: cargo test --no-default-features
       - name: check constrandom
-        uses: actions-rs/cargo@v1
-        with:
-          command: check
-          args: --no-default-features --features compile-time-rng
+        run: cargo check --no-default-features --features compile-time-rng
       - name: test constrandom
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --no-default-features --features compile-time-rng
+        run: cargo test --no-default-features --features compile-time-rng
       - name: check fixed-seed
-        uses: actions-rs/cargo@v1
-        with:
-          command: check
-          args: --no-default-features --features std
+        run: cargo check --no-default-features --features std
       - name: check
-        uses: actions-rs/cargo@v1
-        with:
-          command: check
+        run: cargo check
       - name: test
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
+        run: cargo test
   nightly:
     name: nightly
     runs-on: ubuntu-latest
     env:
         RUSTFLAGS: -C target-cpu=native
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Install latest nightly
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
             toolchain: nightly
-            override: true
             components: clippy
       - name: check nightly
-        uses: actions-rs/cargo@v1
-        with:
-          command: check
-          args: -Z msrv-policy
+        run: cargo check -Z msrv-policy
       - name: test nightly
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
+        run: cargo test
       - name: check serde
-        uses: actions-rs/cargo@v1
-        with:
-          command: check
-          args: --features serde
+        run: cargo check --features serde
       - name: test serde
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --features serde
+        run: cargo test --features serde
   linux_arm7:
     name: Linux ARMv7
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: stable
-          target: armv7-unknown-linux-gnueabihf
-      - uses: actions-rs/cargo@v1
-        with:
-          command: check
-          args: --target armv7-unknown-linux-gnueabihf
+          targets: armv7-unknown-linux-gnueabihf
+      - run: cargo check --target armv7-unknown-linux-gnueabihf
   aarch64-apple-darwin:
     name: Aarch64 Apple Darwin
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: stable
-          target: aarch64-apple-darwin
-      - uses: actions-rs/cargo@v1
-        with:
-          command: check
-          args: --target aarch64-apple-darwin
+          targets: aarch64-apple-darwin
+      - run: cargo check --target aarch64-apple-darwin
   i686-unknown-linux-gnu:
     name: Linux i686
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: stable
-          target: i686-unknown-linux-gnu
+          targets: i686-unknown-linux-gnu
       - name: Install cross compile tools
         run: sudo apt-get install -y gcc-multilib libc6-i386 libc6-dev-i386
-      - uses: actions-rs/cargo@v1
-        with:
-          command: check
-          args: --target i686-unknown-linux-gnu
-      - uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --target i686-unknown-linux-gnu
+      - run: cargo check --target i686-unknown-linux-gnu
+      - run: cargo test --target i686-unknown-linux-gnu
   x86_64-unknown-linux-gnu:
     name: Linux x86_64 - nightly
     runs-on: ubuntu-latest
     env:
         RUSTFLAGS: -C target-cpu=skylake -C target-feature=+aes
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: nightly
-          override: true
-          target: x86_64-unknown-linux-gnu
-      - uses: actions-rs/cargo@v1
-        with:
-          command: check
-          args: --target x86_64-unknown-linux-gnu
-      - uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --target x86_64-unknown-linux-gnu
+          targets: x86_64-unknown-linux-gnu
+      - run: cargo check --target x86_64-unknown-linux-gnu
+      - run: cargo test --target x86_64-unknown-linux-gnu
   thumbv6m:
     name: thumbv6m
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: stable
-          target: thumbv6m-none-eabi
-      - uses: actions-rs/cargo@v1
-        with:
-          command: check
-          args: --target thumbv6m-none-eabi --no-default-features
+          targets: thumbv6m-none-eabi
+      - run: cargo check --target thumbv6m-none-eabi --no-default-features
   wasm32-unknown-unknown:
     name: wasm
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: stable
-          target: wasm32-unknown-unknown
-      - uses: actions-rs/cargo@v1
-        with:
-          command: check
-          args: --target wasm32-unknown-unknown --no-default-features
+          targets: wasm32-unknown-unknown
+      - run: cargo check --target wasm32-unknown-unknown --no-default-features
   msrv:
     name: MSRV
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Install 1.60.0
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
             toolchain: 1.60.0
       - name: check
-        uses: actions-rs/cargo@v1
-        with:
-          command: check
+        run: cargo check
   no_std:
     name: no-std build
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions-rs/toolchain@v1
+    - uses: actions/checkout@v4
+    - uses: dtolnay/rust-toolchain@master
       with:
         toolchain: nightly
-        override: true
-    - uses: actions-rs/cargo@v1
-      with:
-        command: build
-        args: --manifest-path=no_std_test/Cargo.toml
+    - run: cargo build --manifest-path=no_std_test/Cargo.toml


### PR DESCRIPTION
The following updates are performed:
* update [`actions/checkout`](https://github.com/actions/checkout) to v4
* replace [unmaintained](https://github.com/actions-rs/toolchain/issues/216) `actions-rs/toolchain` by [`dtolnay/rust-toolchain`](https://github.com/dtolnay/rust-toolchain)
* replace unmaintained `actions-rs/cargo` by direct invocation of `cargo`

Still using the outdated / unmaintained actions will generate several warnings in CI runs, for example in https://github.com/tkaitchuck/aHash/actions/runs/7359670025:

> The following actions uses node12 which is deprecated and will be forced to run on node16: actions/checkout@v2, actions-rs/toolchain@v1, actions-rs/cargo@v1. For more info: https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/

The PR will get rid of those warnings.