### PR TITLE
Bump rust-version to 1.72.0

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -117,10 +117,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Install 1.60.0
+      - name: Install 1.72.0
         uses: dtolnay/rust-toolchain@master
         with:
-            toolchain: 1.60.0
+            toolchain: 1.72.0
       - name: check
         run: cargo check
   no_std:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2018"
 readme = "README.md"
 build = "./build.rs"
 exclude = ["/smhasher", "/benchmark_tools"]
-rust-version = "1.60.0"
+rust-version = "1.72.0"
 
 [lib]
 name = "ahash"


### PR DESCRIPTION
Closes #195

Bump MSRV since requires functions stabilized in Rust 1.72.0