### PR TITLE
patch ahash 0.7.x to diable stdsimd in unsupported nightlies

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -7,7 +7,9 @@ fn main() {
     if let Some(channel) = version_check::Channel::read() {
         if channel.supports_features() {
             println!("cargo:rustc-cfg=feature=\"specialize\"");
-            println!("cargo:rustc-cfg=feature=\"stdsimd\"");
+            if version_check::Version::read().map_or(false, |v| v.at_most("1.77.9")) {
+                println!("cargo:rustc-cfg=feature=\"stdsimd\"");
+            }
         }
     }
     let os = env::var("CARGO_CFG_TARGET_OS").expect("CARGO_CFG_TARGET_OS was not set");


### PR DESCRIPTION
This keeps the stdsimd feature working for older nightlies, so there shouldn't be any loss of functionality.

