### PR TITLE
Remove build-time check for stdsimd feature (0.7 branch)

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -7,7 +7,6 @@ fn main() {
     if let Some(channel) = version_check::Channel::read() {
         if channel.supports_features() {
             println!("cargo:rustc-cfg=feature=\"specialize\"");
-            println!("cargo:rustc-cfg=feature=\"stdsimd\"");
         }
     }
     let os = env::var("CARGO_CFG_TARGET_OS").expect("CARGO_CFG_TARGET_OS was not set");


### PR DESCRIPTION
In the same vein as https://github.com/tkaitchuck/aHash/pull/183

Fixes #200 for 0.7 users

Would highly appreciate a release of this.