### PR TITLE
Issue 210: Strengthen fastpath for u64 hashes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -98,7 +98,7 @@ fxhash = "0.2.1"
 hex = "0.4.2"
 rand = "0.8.5"
 serde_json = "1.0.59"
-hashbrown = "0.12.3"
+hashbrown = "0.14.3"
 
 [package.metadata.docs.rs]
 rustc-args = ["-C", "target-feature=+aes"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -97,6 +97,7 @@ fnv = "1.0.5"
 fxhash = "0.2.1"
 hex = "0.4.2"
 rand = "0.8.5"
+pcg-mwc = "0.2.1"
 serde_json = "1.0.59"
 hashbrown = "0.14.3"
 

--- a/src/aes_hash.rs
+++ b/src/aes_hash.rs
@@ -252,6 +252,7 @@ impl Hasher for AHasherU64 {
     #[inline]
     fn write_u64(&mut self, i: u64) {
         self.buffer = folded_multiply(i ^ self.buffer, MULTIPLE);
+        self.pad = self.pad.wrapping_add(i);
     }
 
     #[inline]

--- a/src/fallback_hash.rs
+++ b/src/fallback_hash.rs
@@ -237,6 +237,7 @@ impl Hasher for AHasherU64 {
     #[inline]
     fn write_u64(&mut self, i: u64) {
         self.buffer = folded_multiply(i ^ self.buffer, MULTIPLE);
+        self.pad = self.pad.wrapping_add(i);
     }
 
     #[inline]
@@ -341,7 +342,6 @@ impl Hasher for AHasherStr {
 
 #[cfg(test)]
 mod tests {
-    use crate::convert::Convert;
     use crate::fallback_hash::*;
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -319,7 +319,6 @@ mod test {
     use crate::specialize::CallHasher;
     use crate::*;
     use std::collections::HashMap;
-    use std::hash::Hash;
 
     #[test]
     fn test_ahash_alias_map_construction() {

--- a/src/operations.rs
+++ b/src/operations.rs
@@ -184,7 +184,6 @@ pub(crate) fn add_in_length(enc: &mut u128, len: u64) {
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::convert::Convert;
 
     // This is code to search for the shuffle constant
     //


### PR DESCRIPTION
Fixes #210  by making the rotation dependent on the input value.