### PR TITLE
Update to criterion 0.5.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2018"
 readme = "README.md"
 build = "./build.rs"
 exclude = ["/smhasher", "/benchmark_tools"]
-rust-version = "1.60.0"
+rust-version = "1.63.0"
 
 [lib]
 name = "ahash"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -91,7 +91,7 @@ once_cell = { version = "1.18.0", default-features = false, features = ["alloc"]
 
 [dev-dependencies]
 no-panic = "0.1.10"
-criterion = {version =  "0.3.2", features = ["html_reports"] }
+criterion = {version =  "0.5.1", features = ["html_reports"] }
 seahash = "4.0"
 fnv = "1.0.5"
 fxhash = "0.2.1"


### PR DESCRIPTION
Migrate to the latest version of the benchmark library. No code changes required.

Addresses two audit warnings:

- atty is unmaintained and 0.2.14 is [unsound](https://rustsec.org/advisories/RUSTSEC-2021-0145)
- serde_cbor is [unmaintained](https://rustsec.org/advisories/RUSTSEC-2021-0127)

Note that this requires an MSRV bump to 1.63.0 for the atty replacement.