### PR TITLE
Support specializing get_hash without nightly

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,6 +85,7 @@ cfg-if = "1.0"
 portable-atomic = { version = "1.0.0", optional = true }
 getrandom = { version = "0.2.7", optional = true }
 zerocopy = { version = "0.7.31", default-features = false, features = ["simd"] }
+typeid = "1.0"
 
 [target.'cfg(not(all(target_arch = "arm", target_os = "none")))'.dependencies]
 once_cell = { version = "1.18.0", default-features = false, features = ["alloc"] }

--- a/build.rs
+++ b/build.rs
@@ -7,9 +7,6 @@ fn main() {
     if let Some(true) = version_check::is_min_version("1.71.0") {
         println!("cargo:rustc-cfg=build_hasher_hash_one");
     }
-    if let Some(true) = version_check::supports_feature("specialize") {
-        println!("cargo:rustc-cfg=feature=\"specialize\"");
-    }
     let arch = env::var("CARGO_CFG_TARGET_ARCH").expect("CARGO_CFG_TARGET_ARCH was not set");
     if arch.eq_ignore_ascii_case("x86_64")
         || arch.eq_ignore_ascii_case("aarch64")

--- a/build.rs
+++ b/build.rs
@@ -4,6 +4,9 @@ use std::env;
 
 fn main() {
     println!("cargo:rerun-if-changed=build.rs");
+    if let Some(true) = version_check::is_min_version("1.71.0") {
+        println!("cargo:rustc-cfg=build_hasher_hash_one");
+    }
     if let Some(true) = version_check::supports_feature("specialize") {
         println!("cargo:rustc-cfg=feature=\"specialize\"");
     }

--- a/src/aes_hash.rs
+++ b/src/aes_hash.rs
@@ -94,7 +94,6 @@ impl AHasher {
     }
 
     #[inline]
-    #[cfg(feature = "specialize")]
     fn short_finish(&self) -> u64 {
         let combined = aesenc(self.sum, self.enc);
         let result: [u64; 2] = aesdec(combined, combined).convert();
@@ -214,14 +213,12 @@ impl Hasher for AHasher {
     }
 }
 
-#[cfg(feature = "specialize")]
 pub(crate) struct AHasherU64 {
     pub(crate) buffer: u64,
     pub(crate) pad: u64,
 }
 
 /// A specialized hasher for only primitives under 64 bits.
-#[cfg(feature = "specialize")]
 impl Hasher for AHasherU64 {
     #[inline]
     fn finish(&self) -> u64 {
@@ -264,11 +261,9 @@ impl Hasher for AHasherU64 {
     }
 }
 
-#[cfg(feature = "specialize")]
 pub(crate) struct AHasherFixed(pub AHasher);
 
 /// A specialized hasher for fixed size primitives larger than 64 bits.
-#[cfg(feature = "specialize")]
 impl Hasher for AHasherFixed {
     #[inline]
     fn finish(&self) -> u64 {
@@ -311,12 +306,10 @@ impl Hasher for AHasherFixed {
     }
 }
 
-#[cfg(feature = "specialize")]
 pub(crate) struct AHasherStr(pub AHasher);
 
 /// A specialized hasher for strings
 /// Note that the other types don't panic because the hash impl for String tacks on an unneeded call. (As does vec)
-#[cfg(feature = "specialize")]
 impl Hasher for AHasherStr {
     #[inline]
     fn finish(&self) -> u64 {

--- a/src/fallback_hash.rs
+++ b/src/fallback_hash.rs
@@ -115,7 +115,6 @@ impl AHasher {
     }
 
     #[inline]
-    #[cfg(feature = "specialize")]
     fn short_finish(&self) -> u64 {
         folded_multiply(self.buffer, self.pad)
     }
@@ -199,14 +198,12 @@ impl Hasher for AHasher {
     }
 }
 
-#[cfg(feature = "specialize")]
 pub(crate) struct AHasherU64 {
     pub(crate) buffer: u64,
     pub(crate) pad: u64,
 }
 
 /// A specialized hasher for only primitives under 64 bits.
-#[cfg(feature = "specialize")]
 impl Hasher for AHasherU64 {
     #[inline]
     fn finish(&self) -> u64 {
@@ -250,11 +247,9 @@ impl Hasher for AHasherU64 {
     }
 }
 
-#[cfg(feature = "specialize")]
 pub(crate) struct AHasherFixed(pub AHasher);
 
 /// A specialized hasher for fixed size primitives larger than 64 bits.
-#[cfg(feature = "specialize")]
 impl Hasher for AHasherFixed {
     #[inline]
     fn finish(&self) -> u64 {
@@ -297,12 +292,10 @@ impl Hasher for AHasherFixed {
     }
 }
 
-#[cfg(feature = "specialize")]
 pub(crate) struct AHasherStr(pub AHasher);
 
 /// A specialized hasher for a single string
 /// Note that the other types don't panic because the hash impl for String tacks on an unneeded call. (As does vec)
-#[cfg(feature = "specialize")]
 impl Hasher for AHasherStr {
     #[inline]
     fn finish(&self) -> u64 {

--- a/src/hash_quality_test.rs
+++ b/src/hash_quality_test.rs
@@ -406,9 +406,6 @@ mod fallback_tests {
 
     #[test]
     fn fallback_keys_affect_every_byte() {
-        //For fallback second key is not used in every hash.
-        #[cfg(all(not(feature = "specialize"), feature = "folded_multiply"))]
-        test_keys_affect_every_byte(0, |a, b| AHasher::new_with_keys(a ^ b, a));
         test_keys_affect_every_byte("", |a, b| AHasher::new_with_keys(a ^ b, a));
         test_keys_affect_every_byte((0, 0), |a, b| AHasher::new_with_keys(a ^ b, a));
     }
@@ -504,8 +501,6 @@ mod aes_tests {
 
     #[test]
     fn aes_keys_affect_every_byte() {
-        #[cfg(not(feature = "specialize"))]
-        test_keys_affect_every_byte(0, AHasher::test_with_keys);
         test_keys_affect_every_byte("", AHasher::test_with_keys);
         test_keys_affect_every_byte((0, 0), AHasher::test_with_keys);
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -97,7 +97,6 @@ Note the import of [HashMapExt]. This is needed for the constructor.
 #![deny(clippy::correctness, clippy::complexity, clippy::perf)]
 #![allow(clippy::pedantic, clippy::cast_lossless, clippy::unreadable_literal)]
 #![cfg_attr(all(not(test), not(feature = "std")), no_std)]
-#![cfg_attr(feature = "specialize", feature(min_specialization))]
 #![cfg_attr(feature = "nightly-arm-aes", feature(stdarch_arm_neon_intrinsics))]
 
 #[macro_use]
@@ -146,8 +145,6 @@ mod specialize;
 pub use crate::random_state::RandomState;
 
 use core::hash::BuildHasher;
-use core::hash::Hash;
-use core::hash::Hasher;
 
 #[cfg(feature = "std")]
 /// A convenience trait that can be used together with the type aliases defined to
@@ -248,63 +245,6 @@ impl Default for AHasher {
     }
 }
 
-/// Used for specialization. (Sealed)
-pub(crate) trait BuildHasherExt: BuildHasher {
-    #[doc(hidden)]
-    fn hash_as_u64<T: Hash + ?Sized>(&self, value: &T) -> u64;
-
-    #[doc(hidden)]
-    fn hash_as_fixed_length<T: Hash + ?Sized>(&self, value: &T) -> u64;
-
-    #[doc(hidden)]
-    fn hash_as_str<T: Hash + ?Sized>(&self, value: &T) -> u64;
-}
-
-impl<B: BuildHasher> BuildHasherExt for B {
-    #[inline]
-    #[cfg(feature = "specialize")]
-    default fn hash_as_u64<T: Hash + ?Sized>(&self, value: &T) -> u64 {
-        let mut hasher = self.build_hasher();
-        value.hash(&mut hasher);
-        hasher.finish()
-    }
-    #[inline]
-    #[cfg(not(feature = "specialize"))]
-    fn hash_as_u64<T: Hash + ?Sized>(&self, value: &T) -> u64 {
-        let mut hasher = self.build_hasher();
-        value.hash(&mut hasher);
-        hasher.finish()
-    }
-    #[inline]
-    #[cfg(feature = "specialize")]
-    default fn hash_as_fixed_length<T: Hash + ?Sized>(&self, value: &T) -> u64 {
-        let mut hasher = self.build_hasher();
-        value.hash(&mut hasher);
-        hasher.finish()
-    }
-    #[inline]
-    #[cfg(not(feature = "specialize"))]
-    fn hash_as_fixed_length<T: Hash + ?Sized>(&self, value: &T) -> u64 {
-        let mut hasher = self.build_hasher();
-        value.hash(&mut hasher);
-        hasher.finish()
-    }
-    #[inline]
-    #[cfg(feature = "specialize")]
-    default fn hash_as_str<T: Hash + ?Sized>(&self, value: &T) -> u64 {
-        let mut hasher = self.build_hasher();
-        value.hash(&mut hasher);
-        hasher.finish()
-    }
-    #[inline]
-    #[cfg(not(feature = "specialize"))]
-    fn hash_as_str<T: Hash + ?Sized>(&self, value: &T) -> u64 {
-        let mut hasher = self.build_hasher();
-        value.hash(&mut hasher);
-        hasher.finish()
-    }
-}
-
 // #[inline(never)]
 // #[doc(hidden)]
 // pub fn hash_test(input: &[u8]) -> u64 {
@@ -318,6 +258,8 @@ mod test {
     use crate::convert::Convert;
     use crate::specialize::CallHasher;
     use crate::*;
+    use core::hash::Hash;
+    use core::hash::Hasher;
     use std::collections::HashMap;
 
     #[test]

--- a/src/random_state.rs
+++ b/src/random_state.rs
@@ -11,11 +11,6 @@ cfg_if::cfg_if! {
     }
 }
 cfg_if::cfg_if! {
-    if #[cfg(feature = "specialize")]{
-        use crate::BuildHasherExt;
-    }
-}
-cfg_if::cfg_if! {
     if #[cfg(feature = "std")] {
         extern crate std as alloc;
     } else {
@@ -361,6 +356,30 @@ impl RandomState {
         use crate::specialize::CallHasher;
         T::get_hash(&x, self)
     }
+
+    #[inline]
+    pub(crate) fn hash_as_u64<T: Hash + ?Sized>(&self, value: &T) -> u64 {
+        let mut hasher = AHasherU64 {
+            buffer: self.k1,
+            pad: self.k0,
+        };
+        value.hash(&mut hasher);
+        hasher.finish()
+    }
+
+    #[inline]
+    pub(crate) fn hash_as_fixed_length<T: Hash + ?Sized>(&self, value: &T) -> u64 {
+        let mut hasher = AHasherFixed(self.build_hasher());
+        value.hash(&mut hasher);
+        hasher.finish()
+    }
+
+    #[inline]
+    pub(crate) fn hash_as_str<T: Hash + ?Sized>(&self, value: &T) -> u64 {
+        let mut hasher = AHasherStr(self.build_hasher());
+        value.hash(&mut hasher);
+        hasher.finish()
+    }
 }
 
 /// Creates an instance of RandomState using keys obtained from the random number generator.
@@ -462,33 +481,6 @@ impl BuildHasher for RandomState {
     #[inline]
     fn hash_one<T: Hash>(&self, x: T) -> u64 {
         RandomState::hash_one(self, x)
-    }
-}
-
-#[cfg(feature = "specialize")]
-impl BuildHasherExt for RandomState {
-    #[inline]
-    fn hash_as_u64<T: Hash + ?Sized>(&self, value: &T) -> u64 {
-        let mut hasher = AHasherU64 {
-            buffer: self.k1,
-            pad: self.k0,
-        };
-        value.hash(&mut hasher);
-        hasher.finish()
-    }
-
-    #[inline]
-    fn hash_as_fixed_length<T: Hash + ?Sized>(&self, value: &T) -> u64 {
-        let mut hasher = AHasherFixed(self.build_hasher());
-        value.hash(&mut hasher);
-        hasher.finish()
-    }
-
-    #[inline]
-    fn hash_as_str<T: Hash + ?Sized>(&self, value: &T) -> u64 {
-        let mut hasher = AHasherStr(self.build_hasher());
-        value.hash(&mut hasher);
-        hasher.finish()
     }
 }
 

--- a/src/random_state.rs
+++ b/src/random_state.rs
@@ -458,7 +458,7 @@ impl BuildHasher for RandomState {
     /// implementation of [`Hash`].  The way to create a combined hash of
     /// multiple values is to call [`Hash::hash`] multiple times using the same
     /// [`Hasher`], not to call this method repeatedly and combine the results.
-    #[cfg(feature = "specialize")]
+    #[cfg(build_hasher_hash_one)]
     #[inline]
     fn hash_one<T: Hash>(&self, x: T) -> u64 {
         RandomState::hash_one(self, x)

--- a/tests/bench.rs
+++ b/tests/bench.rs
@@ -1,5 +1,3 @@
-#![cfg_attr(feature = "specialize", feature(build_hasher_simple_hash_one))]
-
 use ahash::{AHasher, RandomState};
 use criterion::*;
 use fxhash::FxHasher;

--- a/tests/map_tests.rs
+++ b/tests/map_tests.rs
@@ -1,5 +1,3 @@
-#![cfg_attr(feature = "specialize", feature(build_hasher_simple_hash_one))]
-
 use std::hash::{BuildHasher, Hash, Hasher};
 
 use ahash::RandomState;
@@ -151,13 +149,13 @@ fn check_for_collisions<H: Hash, B: BuildHasher>(build_hasher: &B, items: &[H], 
     );
 }
 
-#[cfg(feature = "specialize")]
+#[cfg(build_hasher_hash_one)]
 #[allow(unused)] // False positive
 fn hash<H: Hash, B: BuildHasher>(b: &H, build_hasher: &B) -> u64 {
     build_hasher.hash_one(b)
 }
 
-#[cfg(not(feature = "specialize"))]
+#[cfg(not(build_hasher_hash_one))]
 #[allow(unused)] // False positive
 fn hash<H: Hash, B: BuildHasher>(b: &H, build_hasher: &B) -> u64 {
     let mut hasher = build_hasher.build_hasher();


### PR DESCRIPTION
Submitting as an alternative to #239. Benchmarks:

**Before:**

```console
RUSTFLAGS='-Ctarget-cpu=native' cargo bench --bench ahash
    aeshash/u8              time:   [994.20 ps 995.35 ps 996.54 ps]                        
    aeshash/u16             time:   [994.81 ps 995.50 ps 996.21 ps]                         
    aeshash/u32             time:   [1.0140 ns 1.0169 ns 1.0204 ns]                         
    aeshash/u64             time:   [988.77 ps 989.85 ps 991.07 ps]                         
    aeshash/u128            time:   [501.29 ps 502.12 ps 503.08 ps]                          
    aeshash/strings         time:   [57.541 ns 57.576 ns 57.615 ns]                            

cargo bench --bench ahash
    fallbackhash/u8         time:   [976.34 ps 977.16 ps 978.05 ps]                             
    fallbackhash/u16        time:   [982.23 ps 983.48 ps 984.79 ps]                              
    fallbackhash/u32        time:   [983.96 ps 986.30 ps 989.23 ps]                              
    fallbackhash/u64        time:   [976.09 ps 980.99 ps 987.61 ps]                              
    fallbackhash/u128       time:   [1.2632 ns 1.2644 ns 1.2657 ns]                               
    fallbackhash/strings    time:   [129.09 ns 129.21 ns 129.33 ns]                                 

RUSTFLAGS='-Zallow-features= -Ctarget-cpu=native' cargo bench --bench ahash
    aeshash/u8              time:   [551.31 ps 551.92 ps 552.62 ps]                        
    aeshash/u16             time:   [587.73 ps 588.50 ps 589.33 ps]                         
    aeshash/u32             time:   [548.83 ps 550.01 ps 551.29 ps]                         
    aeshash/u64             time:   [549.42 ps 550.84 ps 552.65 ps]                         
    aeshash/u128            time:   [557.69 ps 558.17 ps 558.70 ps]                          
    aeshash/strings         time:   [57.197 ns 57.271 ns 57.355 ns]                            

RUSTFLAGS='-Zallow-features=' cargo bench --bench ahash
    fallbackhash/u8         time:   [1.1932 ns 1.1941 ns 1.1951 ns]                             
    fallbackhash/u16        time:   [1.2140 ns 1.2161 ns 1.2190 ns]                              
    fallbackhash/u32        time:   [1.2145 ns 1.2160 ns 1.2176 ns]                              
    fallbackhash/u64        time:   [1.2148 ns 1.2194 ns 1.2247 ns]                              
    fallbackhash/u128       time:   [1.4800 ns 1.4820 ns 1.4842 ns]                               
    fallbackhash/strings    time:   [129.03 ns 129.26 ns 129.55 ns]                                 
```

**After:**

```console
RUSTFLAGS='-Zallow-features= -Ctarget-cpu=native' cargo bench --bench ahash
    aeshash/u8              time:   [990.82 ps 991.44 ps 992.03 ps]                        
    aeshash/u16             time:   [986.98 ps 988.56 ps 990.37 ps]                         
    aeshash/u32             time:   [995.33 ps 996.65 ps 998.35 ps]                         
    aeshash/u64             time:   [987.58 ps 988.99 ps 990.64 ps]                         
    aeshash/u128            time:   [506.18 ps 507.51 ps 509.45 ps]                          
    aeshash/strings         time:   [57.803 ns 57.859 ns 57.923 ns]                            

RUSTFLAGS='-Zallow-features=' cargo bench --bench ahash
    fallbackhash/u8         time:   [973.12 ps 973.98 ps 974.93 ps]                             
    fallbackhash/u16        time:   [976.37 ps 977.22 ps 978.17 ps]                              
    fallbackhash/u32        time:   [984.10 ps 984.82 ps 985.56 ps]                              
    fallbackhash/u64        time:   [977.77 ps 978.66 ps 979.64 ps]                              
    fallbackhash/u128       time:   [1.2595 ns 1.2606 ns 1.2618 ns]                               
    fallbackhash/strings    time:   [129.86 ns 130.00 ns 130.18 ns]                                 
```

It's clear that we are now getting exactly the specialized behavior of both aeshash and fallbackhash, even without the use of unstable min_specialization.