### PR TITLE
Added optional support for mem_dbg crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,8 @@ doc = true
 [features]
 default = ["std", "runtime-rng"]
 
+mem_dbg = ["dep:mem_dbg", "std"]
+
 # Enabling this will enable `AHashMap` and `AHashSet`.
 std = []
 
@@ -85,6 +87,7 @@ cfg-if = "1.0"
 portable-atomic = { version = "1.0.0", optional = true }
 getrandom = { version = "0.2.7", optional = true }
 zerocopy = { version = "0.7.31", default-features = false, features = ["simd"] }
+mem_dbg = {version="0.2.4", optional = true}
 
 [target.'cfg(not(all(target_arch = "arm", target_os = "none")))'.dependencies]
 once_cell = { version = "1.18.0", default-features = false, features = ["alloc"] }

--- a/benchmark_tools/src/persisting_hasher.rs
+++ b/benchmark_tools/src/persisting_hasher.rs
@@ -10,6 +10,7 @@ use std::process::id;
 static GLOBAL_COUNT: AtomicU64 = AtomicU64::new(0);
 static GLOBAL_OUT: OnceCell<Arc<Mutex<BufWriter<File>>>> = OnceCell::new();
 
+#[cfg_attr(feature = "mem_dbg", derive(mem_dbg::MemSize, mem_dbg::MemDbg))]
 pub struct PersistingHasherBuilder {
     id: u64,
     out: Arc<Mutex<BufWriter<File>>>,
@@ -44,6 +45,7 @@ impl BuildHasher for PersistingHasherBuilder {
     }
 }
 
+#[cfg_attr(feature = "mem_dbg", derive(mem_dbg::MemSize, mem_dbg::MemDbg))]
 pub struct PersistingHasher {
     /// Used to compute a hash
     hash: u64,

--- a/src/aes_hash.rs
+++ b/src/aes_hash.rs
@@ -215,6 +215,7 @@ impl Hasher for AHasher {
 }
 
 #[cfg(feature = "specialize")]
+#[cfg_attr(feature = "mem_dbg", derive(mem_dbg::MemSize, mem_dbg::MemDbg))]
 pub(crate) struct AHasherU64 {
     pub(crate) buffer: u64,
     pub(crate) pad: u64,
@@ -265,6 +266,7 @@ impl Hasher for AHasherU64 {
 }
 
 #[cfg(feature = "specialize")]
+#[cfg_attr(feature = "mem_dbg", derive(mem_dbg::MemSize, mem_dbg::MemDbg))]
 pub(crate) struct AHasherFixed(pub AHasher);
 
 /// A specialized hasher for fixed size primitives larger than 64 bits.
@@ -312,6 +314,7 @@ impl Hasher for AHasherFixed {
 }
 
 #[cfg(feature = "specialize")]
+#[cfg_attr(feature = "mem_dbg", derive(mem_dbg::MemSize, mem_dbg::MemDbg))]
 pub(crate) struct AHasherStr(pub AHasher);
 
 /// A specialized hasher for strings

--- a/src/aes_hash.rs
+++ b/src/aes_hash.rs
@@ -16,6 +16,7 @@ use core::hash::Hasher;
 /// start with the same data.
 ///
 #[derive(Debug, Clone)]
+#[cfg_attr(feature = "mem_dbg", derive(mem_dbg::MemSize, mem_dbg::MemDbg))]
 pub struct AHasher {
     enc: u128,
     sum: u128,

--- a/src/fallback_hash.rs
+++ b/src/fallback_hash.rs
@@ -20,6 +20,7 @@ const ROT: u32 = 23; //17
 /// start with the same data.
 ///
 #[derive(Debug, Clone)]
+#[cfg_attr(feature = "mem_dbg", derive(mem_dbg::MemSize, mem_dbg::MemDbg))]
 pub struct AHasher {
     buffer: u64,
     pad: u64,
@@ -200,6 +201,7 @@ impl Hasher for AHasher {
 }
 
 #[cfg(feature = "specialize")]
+#[cfg_attr(feature = "mem_dbg", derive(mem_dbg::MemSize, mem_dbg::MemDbg))]
 pub(crate) struct AHasherU64 {
     pub(crate) buffer: u64,
     pub(crate) pad: u64,
@@ -251,6 +253,7 @@ impl Hasher for AHasherU64 {
 }
 
 #[cfg(feature = "specialize")]
+#[cfg_attr(feature = "mem_dbg", derive(mem_dbg::MemSize, mem_dbg::MemDbg))]
 pub(crate) struct AHasherFixed(pub AHasher);
 
 /// A specialized hasher for fixed size primitives larger than 64 bits.
@@ -298,6 +301,7 @@ impl Hasher for AHasherFixed {
 }
 
 #[cfg(feature = "specialize")]
+#[cfg_attr(feature = "mem_dbg", derive(mem_dbg::MemSize, mem_dbg::MemDbg))]
 pub(crate) struct AHasherStr(pub AHasher);
 
 /// A specialized hasher for a single string

--- a/src/hash_map.rs
+++ b/src/hash_map.rs
@@ -18,6 +18,7 @@ use crate::RandomState;
 /// A [`HashMap`](std::collections::HashMap) using [`RandomState`](crate::RandomState) to hash the items.
 /// (Requires the `std` feature to be enabled.)
 #[derive(Clone)]
+#[cfg_attr(feature = "mem_dbg", derive(mem_dbg::MemSize, mem_dbg::MemDbg))]
 pub struct AHashMap<K, V, S = crate::RandomState>(HashMap<K, V, S>);
 
 impl<K, V> From<HashMap<K, V, crate::RandomState>> for AHashMap<K, V> {

--- a/src/hash_set.rs
+++ b/src/hash_set.rs
@@ -14,6 +14,7 @@ use serde::{
 /// A [`HashSet`](std::collections::HashSet) using [`RandomState`](crate::RandomState) to hash the items.
 /// (Requires the `std` feature to be enabled.)
 #[derive(Clone)]
+#[cfg_attr(feature = "mem_dbg", derive(mem_dbg::MemSize, mem_dbg::MemDbg))]
 pub struct AHashSet<T, S = RandomState>(HashSet<T, S>);
 
 impl<T> From<HashSet<T, RandomState>> for AHashSet<T> {

--- a/src/random_state.rs
+++ b/src/random_state.rs
@@ -217,6 +217,7 @@ cfg_if::cfg_if! {
 /// |`with_seeds`   | Fixed               |`u64` x 4|
 ///
 #[derive(Clone)]
+#[cfg_attr(feature = "mem_dbg", derive(mem_dbg::MemSize, mem_dbg::MemDbg))]
 pub struct RandomState {
     pub(crate) k0: u64,
     pub(crate) k1: u64,

--- a/tests/nopanic.rs
+++ b/tests/nopanic.rs
@@ -20,6 +20,7 @@ fn hash_test_final_wrapper(num: i32, string: &str) {
     hash_test_final(num, string);
 }
 
+#[cfg_attr(feature = "mem_dbg", derive(mem_dbg::MemSize, mem_dbg::MemDbg))]
 struct SimpleBuildHasher {
     hasher: AHasher,
 }


### PR DESCRIPTION
As per the title, I have added optional support for the [mem_dbg](https://github.com/zommiommy/mem_dbg-rs) crate, a rust library to estimate accurately and quickly the size of objects. The reason I needed to put it here on Hasher objects and the likes is that several libraries that I am benchmarking use this library and have the structs from this library within their structs. 

By adding this derive, it becomes trivial to measure accurately their memory requirements.