### PR TITLE
chore: bump zero-copy

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,7 +84,7 @@ serde = { version = "1.0.117", optional = true }
 cfg-if = "1.0"
 portable-atomic = { version = "1.0.0", optional = true }
 getrandom = { version = "0.2.7", optional = true }
-zerocopy = { version = "0.7.31", default-features = false, features = ["simd"] }
+zerocopy = { version = "0.8.24", default-features = false, features = ["simd"] }
 
 [target.'cfg(not(all(target_arch = "arm", target_os = "none")))'.dependencies]
 once_cell = { version = "1.18.0", default-features = false, features = ["alloc"] }

--- a/src/hash_quality_test.rs
+++ b/src/hash_quality_test.rs
@@ -70,8 +70,8 @@ fn test_no_full_collisions<T: Hasher>(gen_hash: impl Fn() -> T) {
     gen_combinations(&options, 7, Vec::new(), &mut combinations);
     let mut map: HashMap<u64, Vec<u8>> = HashMap::new();
     for combination in combinations {
-        use zerocopy::AsBytes;
-        let array = combination.as_slice().as_bytes().to_vec();
+        use zerocopy::IntoBytes;
+        let array = combination.as_bytes().to_vec();
         let mut hasher = gen_hash();
         hasher.write(&array);
         let hash = hasher.finish();


### PR DESCRIPTION
A new version of zero-copy is available.

The current version of ahash is rejected by our CI because it introduces a conflicting dependency with other crates which have jumped to this version of zero-copy.