### PR TITLE
Make CallHasher specific to ahash::RandomState

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -146,8 +146,6 @@ mod specialize;
 pub use crate::random_state::RandomState;
 
 use core::hash::BuildHasher;
-use core::hash::Hash;
-use core::hash::Hasher;
 
 #[cfg(feature = "std")]
 /// A convenience trait that can be used together with the type aliases defined to
@@ -248,63 +246,6 @@ impl Default for AHasher {
     }
 }
 
-/// Used for specialization. (Sealed)
-pub(crate) trait BuildHasherExt: BuildHasher {
-    #[doc(hidden)]
-    fn hash_as_u64<T: Hash + ?Sized>(&self, value: &T) -> u64;
-
-    #[doc(hidden)]
-    fn hash_as_fixed_length<T: Hash + ?Sized>(&self, value: &T) -> u64;
-
-    #[doc(hidden)]
-    fn hash_as_str<T: Hash + ?Sized>(&self, value: &T) -> u64;
-}
-
-impl<B: BuildHasher> BuildHasherExt for B {
-    #[inline]
-    #[cfg(feature = "specialize")]
-    default fn hash_as_u64<T: Hash + ?Sized>(&self, value: &T) -> u64 {
-        let mut hasher = self.build_hasher();
-        value.hash(&mut hasher);
-        hasher.finish()
-    }
-    #[inline]
-    #[cfg(not(feature = "specialize"))]
-    fn hash_as_u64<T: Hash + ?Sized>(&self, value: &T) -> u64 {
-        let mut hasher = self.build_hasher();
-        value.hash(&mut hasher);
-        hasher.finish()
-    }
-    #[inline]
-    #[cfg(feature = "specialize")]
-    default fn hash_as_fixed_length<T: Hash + ?Sized>(&self, value: &T) -> u64 {
-        let mut hasher = self.build_hasher();
-        value.hash(&mut hasher);
-        hasher.finish()
-    }
-    #[inline]
-    #[cfg(not(feature = "specialize"))]
-    fn hash_as_fixed_length<T: Hash + ?Sized>(&self, value: &T) -> u64 {
-        let mut hasher = self.build_hasher();
-        value.hash(&mut hasher);
-        hasher.finish()
-    }
-    #[inline]
-    #[cfg(feature = "specialize")]
-    default fn hash_as_str<T: Hash + ?Sized>(&self, value: &T) -> u64 {
-        let mut hasher = self.build_hasher();
-        value.hash(&mut hasher);
-        hasher.finish()
-    }
-    #[inline]
-    #[cfg(not(feature = "specialize"))]
-    fn hash_as_str<T: Hash + ?Sized>(&self, value: &T) -> u64 {
-        let mut hasher = self.build_hasher();
-        value.hash(&mut hasher);
-        hasher.finish()
-    }
-}
-
 // #[inline(never)]
 // #[doc(hidden)]
 // pub fn hash_test(input: &[u8]) -> u64 {
@@ -318,6 +259,8 @@ mod test {
     use crate::convert::Convert;
     use crate::specialize::CallHasher;
     use crate::*;
+    use core::hash::Hash;
+    use core::hash::Hasher;
     use std::collections::HashMap;
 
     #[test]

--- a/src/random_state.rs
+++ b/src/random_state.rs
@@ -11,11 +11,6 @@ cfg_if::cfg_if! {
     }
 }
 cfg_if::cfg_if! {
-    if #[cfg(feature = "specialize")]{
-        use crate::BuildHasherExt;
-    }
-}
-cfg_if::cfg_if! {
     if #[cfg(feature = "std")] {
         extern crate std as alloc;
     } else {
@@ -466,9 +461,9 @@ impl BuildHasher for RandomState {
 }
 
 #[cfg(feature = "specialize")]
-impl BuildHasherExt for RandomState {
+impl RandomState {
     #[inline]
-    fn hash_as_u64<T: Hash + ?Sized>(&self, value: &T) -> u64 {
+    pub(crate) fn hash_as_u64<T: Hash + ?Sized>(&self, value: &T) -> u64 {
         let mut hasher = AHasherU64 {
             buffer: self.k1,
             pad: self.k0,
@@ -478,14 +473,14 @@ impl BuildHasherExt for RandomState {
     }
 
     #[inline]
-    fn hash_as_fixed_length<T: Hash + ?Sized>(&self, value: &T) -> u64 {
+    pub(crate) fn hash_as_fixed_length<T: Hash + ?Sized>(&self, value: &T) -> u64 {
         let mut hasher = AHasherFixed(self.build_hasher());
         value.hash(&mut hasher);
         hasher.finish()
     }
 
     #[inline]
-    fn hash_as_str<T: Hash + ?Sized>(&self, value: &T) -> u64 {
+    pub(crate) fn hash_as_str<T: Hash + ?Sized>(&self, value: &T) -> u64 {
         let mut hasher = AHasherStr(self.build_hasher());
         value.hash(&mut hasher);
         hasher.finish()

--- a/src/specialize.rs
+++ b/src/specialize.rs
@@ -9,8 +9,6 @@ extern crate alloc;
 extern crate std as alloc;
 
 #[cfg(feature = "specialize")]
-use crate::BuildHasherExt;
-#[cfg(feature = "specialize")]
 use alloc::string::String;
 #[cfg(feature = "specialize")]
 use alloc::vec::Vec;

--- a/src/specialize.rs
+++ b/src/specialize.rs
@@ -1,3 +1,4 @@
+use crate::RandomState;
 use core::hash::BuildHasher;
 use core::hash::Hash;
 use core::hash::Hasher;
@@ -18,7 +19,7 @@ use alloc::vec::Vec;
 /// Rather than using a Hasher generically which can hash any value, this provides a way to get a specialized hash
 /// for a specific type. So this may be faster for primitive types.
 pub(crate) trait CallHasher {
-    fn get_hash<H: Hash + ?Sized, B: BuildHasher>(value: &H, build_hasher: &B) -> u64;
+    fn get_hash<H: Hash + ?Sized>(value: &H, build_hasher: &RandomState) -> u64;
 }
 
 #[cfg(not(feature = "specialize"))]
@@ -27,7 +28,7 @@ where
     T: Hash + ?Sized,
 {
     #[inline]
-    fn get_hash<H: Hash + ?Sized, B: BuildHasher>(value: &H, build_hasher: &B) -> u64 {
+    fn get_hash<H: Hash + ?Sized>(value: &H, build_hasher: &RandomState) -> u64 {
         let mut hasher = build_hasher.build_hasher();
         value.hash(&mut hasher);
         hasher.finish()
@@ -40,7 +41,7 @@ where
     T: Hash + ?Sized,
 {
     #[inline]
-    default fn get_hash<H: Hash + ?Sized, B: BuildHasher>(value: &H, build_hasher: &B) -> u64 {
+    default fn get_hash<H: Hash + ?Sized>(value: &H, build_hasher: &RandomState) -> u64 {
         let mut hasher = build_hasher.build_hasher();
         value.hash(&mut hasher);
         hasher.finish()
@@ -52,7 +53,7 @@ macro_rules! call_hasher_impl_u64 {
         #[cfg(feature = "specialize")]
         impl CallHasher for $typ {
             #[inline]
-            fn get_hash<H: Hash + ?Sized, B: BuildHasher>(value: &H, build_hasher: &B) -> u64 {
+            fn get_hash<H: Hash + ?Sized>(value: &H, build_hasher: &RandomState) -> u64 {
                 build_hasher.hash_as_u64(value)
             }
         }
@@ -80,7 +81,7 @@ macro_rules! call_hasher_impl_fixed_length{
         #[cfg(feature = "specialize")]
         impl CallHasher for $typ {
             #[inline]
-            fn get_hash<H: Hash + ?Sized, B: BuildHasher>(value: &H, build_hasher: &B) -> u64 {
+            fn get_hash<H: Hash + ?Sized>(value: &H, build_hasher: &RandomState) -> u64 {
                 build_hasher.hash_as_fixed_length(value)
             }
         }
@@ -99,7 +100,7 @@ call_hasher_impl_fixed_length!(&isize);
 #[cfg(feature = "specialize")]
 impl CallHasher for [u8] {
     #[inline]
-    fn get_hash<H: Hash + ?Sized, B: BuildHasher>(value: &H, build_hasher: &B) -> u64 {
+    fn get_hash<H: Hash + ?Sized>(value: &H, build_hasher: &RandomState) -> u64 {
         build_hasher.hash_as_str(value)
     }
 }
@@ -107,7 +108,7 @@ impl CallHasher for [u8] {
 #[cfg(feature = "specialize")]
 impl CallHasher for Vec<u8> {
     #[inline]
-    fn get_hash<H: Hash + ?Sized, B: BuildHasher>(value: &H, build_hasher: &B) -> u64 {
+    fn get_hash<H: Hash + ?Sized>(value: &H, build_hasher: &RandomState) -> u64 {
         build_hasher.hash_as_str(value)
     }
 }
@@ -115,7 +116,7 @@ impl CallHasher for Vec<u8> {
 #[cfg(feature = "specialize")]
 impl CallHasher for str {
     #[inline]
-    fn get_hash<H: Hash + ?Sized, B: BuildHasher>(value: &H, build_hasher: &B) -> u64 {
+    fn get_hash<H: Hash + ?Sized>(value: &H, build_hasher: &RandomState) -> u64 {
         build_hasher.hash_as_str(value)
     }
 }
@@ -123,7 +124,7 @@ impl CallHasher for str {
 #[cfg(all(feature = "specialize"))]
 impl CallHasher for String {
     #[inline]
-    fn get_hash<H: Hash + ?Sized, B: BuildHasher>(value: &H, build_hasher: &B) -> u64 {
+    fn get_hash<H: Hash + ?Sized>(value: &H, build_hasher: &RandomState) -> u64 {
         build_hasher.hash_as_str(value)
     }
 }

--- a/src/specialize.rs
+++ b/src/specialize.rs
@@ -17,7 +17,7 @@ use alloc::vec::Vec;
 /// Rather than using a Hasher generically which can hash any value, this provides a way to get a specialized hash
 /// for a specific type. So this may be faster for primitive types.
 pub(crate) trait CallHasher {
-    fn get_hash<H: Hash + ?Sized>(value: &H, build_hasher: &RandomState) -> u64;
+    fn get_hash<H: Hash + ?Sized>(value: &H, random_state: &RandomState) -> u64;
 }
 
 #[cfg(not(feature = "specialize"))]
@@ -26,8 +26,8 @@ where
     T: Hash + ?Sized,
 {
     #[inline]
-    fn get_hash<H: Hash + ?Sized>(value: &H, build_hasher: &RandomState) -> u64 {
-        let mut hasher = build_hasher.build_hasher();
+    fn get_hash<H: Hash + ?Sized>(value: &H, random_state: &RandomState) -> u64 {
+        let mut hasher = random_state.build_hasher();
         value.hash(&mut hasher);
         hasher.finish()
     }
@@ -39,8 +39,8 @@ where
     T: Hash + ?Sized,
 {
     #[inline]
-    default fn get_hash<H: Hash + ?Sized>(value: &H, build_hasher: &RandomState) -> u64 {
-        let mut hasher = build_hasher.build_hasher();
+    default fn get_hash<H: Hash + ?Sized>(value: &H, random_state: &RandomState) -> u64 {
+        let mut hasher = random_state.build_hasher();
         value.hash(&mut hasher);
         hasher.finish()
     }
@@ -51,8 +51,8 @@ macro_rules! call_hasher_impl_u64 {
         #[cfg(feature = "specialize")]
         impl CallHasher for $typ {
             #[inline]
-            fn get_hash<H: Hash + ?Sized>(value: &H, build_hasher: &RandomState) -> u64 {
-                build_hasher.hash_as_u64(value)
+            fn get_hash<H: Hash + ?Sized>(value: &H, random_state: &RandomState) -> u64 {
+                random_state.hash_as_u64(value)
             }
         }
     };
@@ -79,8 +79,8 @@ macro_rules! call_hasher_impl_fixed_length{
         #[cfg(feature = "specialize")]
         impl CallHasher for $typ {
             #[inline]
-            fn get_hash<H: Hash + ?Sized>(value: &H, build_hasher: &RandomState) -> u64 {
-                build_hasher.hash_as_fixed_length(value)
+            fn get_hash<H: Hash + ?Sized>(value: &H, random_state: &RandomState) -> u64 {
+                random_state.hash_as_fixed_length(value)
             }
         }
     };
@@ -98,32 +98,32 @@ call_hasher_impl_fixed_length!(&isize);
 #[cfg(feature = "specialize")]
 impl CallHasher for [u8] {
     #[inline]
-    fn get_hash<H: Hash + ?Sized>(value: &H, build_hasher: &RandomState) -> u64 {
-        build_hasher.hash_as_str(value)
+    fn get_hash<H: Hash + ?Sized>(value: &H, random_state: &RandomState) -> u64 {
+        random_state.hash_as_str(value)
     }
 }
 
 #[cfg(feature = "specialize")]
 impl CallHasher for Vec<u8> {
     #[inline]
-    fn get_hash<H: Hash + ?Sized>(value: &H, build_hasher: &RandomState) -> u64 {
-        build_hasher.hash_as_str(value)
+    fn get_hash<H: Hash + ?Sized>(value: &H, random_state: &RandomState) -> u64 {
+        random_state.hash_as_str(value)
     }
 }
 
 #[cfg(feature = "specialize")]
 impl CallHasher for str {
     #[inline]
-    fn get_hash<H: Hash + ?Sized>(value: &H, build_hasher: &RandomState) -> u64 {
-        build_hasher.hash_as_str(value)
+    fn get_hash<H: Hash + ?Sized>(value: &H, random_state: &RandomState) -> u64 {
+        random_state.hash_as_str(value)
     }
 }
 
 #[cfg(all(feature = "specialize"))]
 impl CallHasher for String {
     #[inline]
-    fn get_hash<H: Hash + ?Sized>(value: &H, build_hasher: &RandomState) -> u64 {
-        build_hasher.hash_as_str(value)
+    fn get_hash<H: Hash + ?Sized>(value: &H, random_state: &RandomState) -> u64 {
+        random_state.hash_as_str(value)
     }
 }
 


### PR DESCRIPTION
As pointed out in https://github.com/tkaitchuck/aHash/pull/242#discussion_r2059369948, the `CallHasher` trait used by the specialization feature does not need to work for arbitrary `B: BuildHasher`.

https://github.com/tkaitchuck/aHash/blob/3a54154e997a0810f246c59d058c789abf161dce/src/specialize.rs#L20-L22

It's enough to work for `ahash::random_state::RandomState` only. This trait is private to this crate and is only ever used with ahash's `RandomState`.

https://github.com/tkaitchuck/aHash/blob/6dfeeae7e9f5f7a0e36113076c7d12b222416107/src/specialize.rs#L19-L21

This simplifies the existing nightly-only specialization and also the stable version in https://github.com/tkaitchuck/aHash/pull/242 by eliminating some unreachable branches.