### PR TITLE
Avoid [u64; 4] -> [u128; 2] conversion.

### DIFF
--- a/src/aes_hash.rs
+++ b/src/aes_hash.rs
@@ -1,6 +1,6 @@
 use crate::convert::*;
 use crate::operations::*;
-use crate::random_state::PI;
+use crate::random_state::PI_U128X2;
 use crate::RandomState;
 use core::hash::Hasher;
 
@@ -49,9 +49,8 @@ impl AHasher {
     /// ```
     #[inline]
     pub(crate) fn new_with_keys(key1: u128, key2: u128) -> Self {
-        let pi: [u128; 2] = PI.convert();
-        let key1 = key1 ^ pi[0];
-        let key2 = key2 ^ pi[1];
+        let key1 = key1 ^ PI_U128X2[0];
+        let key2 = key2 ^ PI_U128X2[1];
         Self {
             enc: key1,
             sum: key2,

--- a/src/convert.rs
+++ b/src/convert.rs
@@ -37,7 +37,6 @@ macro_rules! convert_primitive_bytes {
 }
 
 convert!([u128; 4], [u8; 64]);
-convert!([u128; 2], [u64; 4]);
 convert!([u128; 2], [u8; 32]);
 convert!(u128, [u64; 2]);
 convert_primitive_bytes!(u128, [u8; 16]);

--- a/src/fallback_hash.rs
+++ b/src/fallback_hash.rs
@@ -2,7 +2,7 @@ use crate::convert::*;
 use crate::operations::folded_multiply;
 use crate::operations::read_small;
 use crate::operations::MULTIPLE;
-use crate::random_state::PI;
+use crate::random_state::PI_U128X2;
 use crate::RandomState;
 use core::hash::Hasher;
 
@@ -31,9 +31,8 @@ impl AHasher {
     #[inline]
     #[allow(dead_code)] // Is not called if non-fallback hash is used.
     pub(crate) fn new_with_keys(key1: u128, key2: u128) -> AHasher {
-        let pi: [u128; 2] = PI.convert();
-        let key1: [u64; 2] = (key1 ^ pi[0]).convert();
-        let key2: [u64; 2] = (key2 ^ pi[1]).convert();
+        let key1: [u64; 2] = (key1 ^ PI_U128X2[0]).convert();
+        let key2: [u64; 2] = (key2 ^ PI_U128X2[1]).convert();
         AHasher {
             buffer: key1[0],
             pad: key1[1],

--- a/src/random_state.rs
+++ b/src/random_state.rs
@@ -30,11 +30,16 @@ use core::fmt;
 use core::hash::BuildHasher;
 use core::hash::Hasher;
 
-pub(crate) const PI: [u64; 4] = [
+pub(crate) const PI_U64X4: [u64; 4] = [
     0x243f_6a88_85a3_08d3,
     0x1319_8a2e_0370_7344,
     0xa409_3822_299f_31d0,
     0x082e_fa98_ec4e_6c89,
+];
+
+pub(crate) const PI_U128X2: [u128; 2] = [
+    0x1319_8a2e_0370_7344_243f_6a88_85a3_08d3,
+    0x082e_fa98_ec4e_6c89_a409_3822_299f_31d0,
 ];
 
 pub(crate) const PI2: [u64; 4] = [
@@ -101,7 +106,7 @@ cfg_if::cfg_if! {
     } else {
         #[inline]
         fn get_fixed_seeds() -> &'static [[u64; 4]; 2] {
-            &[PI, PI2]
+            &[PI_U64X4, PI2]
         }
     }
 }
@@ -135,14 +140,14 @@ struct DefaultRandomSource {
 impl DefaultRandomSource {
     fn new() -> DefaultRandomSource {
         DefaultRandomSource {
-            counter: AtomicUsize::new(&PI as *const _ as usize),
+            counter: AtomicUsize::new(&PI_U64X4 as *const _ as usize),
         }
     }
 
     #[cfg(all(target_arch = "arm", target_os = "none"))]
     const fn default() -> DefaultRandomSource {
         DefaultRandomSource {
-            counter: AtomicUsize::new(PI[3] as usize),
+            counter: AtomicUsize::new(PI_U64X4[3] as usize),
         }
     }
 }
@@ -501,19 +506,19 @@ mod test {
     #[cfg(all(feature = "runtime-rng", not(all(feature = "compile-time-rng", test))))]
     #[test]
     fn test_not_pi() {
-        assert_ne!(PI, get_fixed_seeds()[0]);
+        assert_ne!(PI_U64X4, get_fixed_seeds()[0]);
     }
 
     #[cfg(all(feature = "compile-time-rng", any(not(feature = "runtime-rng"), test)))]
     #[test]
     fn test_not_pi_const() {
-        assert_ne!(PI, get_fixed_seeds()[0]);
+        assert_ne!(PI_U64X4, get_fixed_seeds()[0]);
     }
 
     #[cfg(all(not(feature = "runtime-rng"), not(feature = "compile-time-rng")))]
     #[test]
     fn test_pi() {
-        assert_eq!(PI, get_fixed_seeds()[0]);
+        assert_eq!(PI_U64X4, get_fixed_seeds()[0]);
     }
 
     #[test]


### PR DESCRIPTION
Avoid the need to implement this conversion by just hard-coding the constant twice.