### PR TITLE
Do not build broken doc test.

### DIFF
--- a/src/aes_hash.rs
+++ b/src/aes_hash.rs
@@ -34,7 +34,7 @@ impl AHasher {
     ///
     /// # Example
     ///
-    /// ```
+    /// ```no_build
     /// use std::hash::Hasher;
     /// use ahash::AHasher;
     ///


### PR DESCRIPTION
This doctest cannot build successfully in recent toolchains because the function is inaccessible to it. Since it is a non-public API, not much is lost by disabling the doctest.