### PR TITLE
Don't condition "aes" support for AArch64 on feature "nightly-arm-aes".

### DIFF
--- a/src/hash_quality_test.rs
+++ b/src/hash_quality_test.rs
@@ -441,7 +441,7 @@ mod fallback_tests {
 ///Basic sanity tests of the cypto properties of aHash.
 #[cfg(any(
     all(any(target_arch = "x86", target_arch = "x86_64"), target_feature = "aes", not(miri)),
-    all(feature = "nightly-arm-aes", target_arch = "aarch64", target_feature = "aes", not(miri)),
+    all(target_arch = "aarch64", target_feature = "aes", not(miri)),
     all(feature = "nightly-arm-aes", target_arch = "arm", target_feature = "aes", not(miri)),
 ))]
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -108,7 +108,7 @@ mod fallback_hash;
 cfg_if::cfg_if! {
     if #[cfg(any(
             all(any(target_arch = "x86", target_arch = "x86_64"), target_feature = "aes", not(miri)),
-            all(feature = "nightly-arm-aes", target_arch = "aarch64", target_feature = "aes", not(miri)),
+            all(target_arch = "aarch64", target_feature = "aes", not(miri)),
             all(feature = "nightly-arm-aes", target_arch = "arm", target_feature = "aes", not(miri)),
         ))] {
         mod aes_hash;

--- a/src/operations.rs
+++ b/src/operations.rs
@@ -112,7 +112,7 @@ pub(crate) fn aesenc(value: u128, xor: u128) -> u128 {
 }
 
 #[cfg(any(
-    all(feature = "nightly-arm-aes", target_arch = "aarch64", target_feature = "aes", not(miri)),
+    all(target_arch = "aarch64", target_feature = "aes", not(miri)),
     all(feature = "nightly-arm-aes", target_arch = "arm", target_feature = "aes", not(miri)),
 ))]
 #[allow(unused)]
@@ -142,7 +142,7 @@ pub(crate) fn aesdec(value: u128, xor: u128) -> u128 {
 }
 
 #[cfg(any(
-    all(feature = "nightly-arm-aes", target_arch = "aarch64", target_feature = "aes", not(miri)),
+    all(target_arch = "aarch64", target_feature = "aes", not(miri)),
     all(feature = "nightly-arm-aes", target_arch = "arm", target_feature = "aes", not(miri)),
 ))]
 #[allow(unused)]

--- a/src/random_state.rs
+++ b/src/random_state.rs
@@ -2,7 +2,7 @@ use core::hash::Hash;
 cfg_if::cfg_if! {
     if #[cfg(any(
         all(any(target_arch = "x86", target_arch = "x86_64"), target_feature = "aes", not(miri)),
-        all(feature = "nightly-arm-aes", target_arch = "aarch64", target_feature = "aes", not(miri)),
+        all(target_arch = "aarch64", target_feature = "aes", not(miri)),
         all(feature = "nightly-arm-aes", target_arch = "arm", target_feature = "aes", not(miri)),
     ))] {
         use crate::aes_hash::*;

--- a/tests/bench.rs
+++ b/tests/bench.rs
@@ -14,7 +14,7 @@ const AHASH_IMPL: &str = if cfg!(any(
         target_feature = "aes",
         not(miri),
     ),
-    all(feature = "nightly-arm-aes", target_arch = "aarch64", target_feature = "aes", not(miri)),
+    all(target_arch = "aarch64", target_feature = "aes", not(miri)),
     all(
         feature = "nightly-arm-aes",
         target_arch = "arm",


### PR DESCRIPTION
The documentation says that this is enabled automatically when the target feature is enabled.