### PR TITLE
Address unexpected_cfg lints.

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -4,10 +4,12 @@ use std::env;
 
 fn main() {
     println!("cargo:rerun-if-changed=build.rs");
+    println!("cargo:rustc-check-cfg=cfg(specialize)");
     if let Some(true) = version_check::supports_feature("specialize") {
-        println!("cargo:rustc-cfg=feature=\"specialize\"");
+        println!("cargo:rustc-cfg=specialize");
     }
     let arch = env::var("CARGO_CFG_TARGET_ARCH").expect("CARGO_CFG_TARGET_ARCH was not set");
+    println!("cargo:rustc-check-cfg=cfg(folded_multiply)");
     if arch.eq_ignore_ascii_case("x86_64")
         || arch.eq_ignore_ascii_case("aarch64")
         || arch.eq_ignore_ascii_case("mips64")
@@ -15,6 +17,6 @@ fn main() {
         || arch.eq_ignore_ascii_case("riscv64gc")
         || arch.eq_ignore_ascii_case("s390x")
     {
-        println!("cargo:rustc-cfg=feature=\"folded_multiply\"");
+        println!("cargo:rustc-cfg=folded_multiply");
     }
 }

--- a/src/aes_hash.rs
+++ b/src/aes_hash.rs
@@ -94,7 +94,7 @@ impl AHasher {
     }
 
     #[inline]
-    #[cfg(feature = "specialize")]
+    #[cfg(specialize)]
     fn short_finish(&self) -> u64 {
         let combined = aesenc(self.sum, self.enc);
         let result: [u64; 2] = aesdec(combined, combined).convert();
@@ -214,14 +214,14 @@ impl Hasher for AHasher {
     }
 }
 
-#[cfg(feature = "specialize")]
+#[cfg(specialize)]
 pub(crate) struct AHasherU64 {
     pub(crate) buffer: u64,
     pub(crate) pad: u64,
 }
 
 /// A specialized hasher for only primitives under 64 bits.
-#[cfg(feature = "specialize")]
+#[cfg(specialize)]
 impl Hasher for AHasherU64 {
     #[inline]
     fn finish(&self) -> u64 {
@@ -264,11 +264,11 @@ impl Hasher for AHasherU64 {
     }
 }
 
-#[cfg(feature = "specialize")]
+#[cfg(specialize)]
 pub(crate) struct AHasherFixed(pub AHasher);
 
 /// A specialized hasher for fixed size primitives larger than 64 bits.
-#[cfg(feature = "specialize")]
+#[cfg(specialize)]
 impl Hasher for AHasherFixed {
     #[inline]
     fn finish(&self) -> u64 {
@@ -311,12 +311,12 @@ impl Hasher for AHasherFixed {
     }
 }
 
-#[cfg(feature = "specialize")]
+#[cfg(specialize)]
 pub(crate) struct AHasherStr(pub AHasher);
 
 /// A specialized hasher for strings
 /// Note that the other types don't panic because the hash impl for String tacks on an unneeded call. (As does vec)
-#[cfg(feature = "specialize")]
+#[cfg(specialize)]
 impl Hasher for AHasherStr {
     #[inline]
     fn finish(&self) -> u64 {

--- a/src/fallback_hash.rs
+++ b/src/fallback_hash.rs
@@ -115,7 +115,7 @@ impl AHasher {
     }
 
     #[inline]
-    #[cfg(feature = "specialize")]
+    #[cfg(specialize)]
     fn short_finish(&self) -> u64 {
         folded_multiply(self.buffer, self.pad)
     }
@@ -199,14 +199,14 @@ impl Hasher for AHasher {
     }
 }
 
-#[cfg(feature = "specialize")]
+#[cfg(specialize)]
 pub(crate) struct AHasherU64 {
     pub(crate) buffer: u64,
     pub(crate) pad: u64,
 }
 
 /// A specialized hasher for only primitives under 64 bits.
-#[cfg(feature = "specialize")]
+#[cfg(specialize)]
 impl Hasher for AHasherU64 {
     #[inline]
     fn finish(&self) -> u64 {
@@ -250,11 +250,11 @@ impl Hasher for AHasherU64 {
     }
 }
 
-#[cfg(feature = "specialize")]
+#[cfg(specialize)]
 pub(crate) struct AHasherFixed(pub AHasher);
 
 /// A specialized hasher for fixed size primitives larger than 64 bits.
-#[cfg(feature = "specialize")]
+#[cfg(specialize)]
 impl Hasher for AHasherFixed {
     #[inline]
     fn finish(&self) -> u64 {
@@ -297,12 +297,12 @@ impl Hasher for AHasherFixed {
     }
 }
 
-#[cfg(feature = "specialize")]
+#[cfg(specialize)]
 pub(crate) struct AHasherStr(pub AHasher);
 
 /// A specialized hasher for a single string
 /// Note that the other types don't panic because the hash impl for String tacks on an unneeded call. (As does vec)
-#[cfg(feature = "specialize")]
+#[cfg(specialize)]
 impl Hasher for AHasherStr {
     #[inline]
     fn finish(&self) -> u64 {

--- a/src/hash_quality_test.rs
+++ b/src/hash_quality_test.rs
@@ -407,7 +407,7 @@ mod fallback_tests {
     #[test]
     fn fallback_keys_affect_every_byte() {
         //For fallback second key is not used in every hash.
-        #[cfg(all(not(feature = "specialize"), feature = "folded_multiply"))]
+        #[cfg(all(not(specialize), folded_multiply))]
         test_keys_affect_every_byte(0, |a, b| AHasher::new_with_keys(a ^ b, a));
         test_keys_affect_every_byte("", |a, b| AHasher::new_with_keys(a ^ b, a));
         test_keys_affect_every_byte((0, 0), |a, b| AHasher::new_with_keys(a ^ b, a));
@@ -504,7 +504,7 @@ mod aes_tests {
 
     #[test]
     fn aes_keys_affect_every_byte() {
-        #[cfg(not(feature = "specialize"))]
+        #[cfg(not(specialize))]
         test_keys_affect_every_byte(0, AHasher::test_with_keys);
         test_keys_affect_every_byte("", AHasher::test_with_keys);
         test_keys_affect_every_byte((0, 0), AHasher::test_with_keys);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -97,7 +97,7 @@ Note the import of [HashMapExt]. This is needed for the constructor.
 #![deny(clippy::correctness, clippy::complexity, clippy::perf)]
 #![allow(clippy::pedantic, clippy::cast_lossless, clippy::unreadable_literal)]
 #![cfg_attr(all(not(test), not(feature = "std")), no_std)]
-#![cfg_attr(feature = "specialize", feature(min_specialization))]
+#![cfg_attr(specialize, feature(min_specialization))]
 #![cfg_attr(feature = "nightly-arm-aes", feature(stdarch_arm_neon_intrinsics))]
 
 #[macro_use]

--- a/src/operations.rs
+++ b/src/operations.rs
@@ -13,14 +13,14 @@ const SHUFFLE_MASK: u128 = 0x020a0700_0c01030e_050f0d08_06090b04_u128;
 //const SHUFFLE_MASK: u128 = 0x040A0700_030E0106_0D050F08_020B0C09_u128;
 
 #[inline(always)]
-#[cfg(feature = "folded_multiply")]
+#[cfg(folded_multiply)]
 pub(crate) const fn folded_multiply(s: u64, by: u64) -> u64 {
     let result = (s as u128).wrapping_mul(by as u128);
     ((result & 0xffff_ffff_ffff_ffff) as u64) ^ ((result >> 64) as u64)
 }
 
 #[inline(always)]
-#[cfg(not(feature = "folded_multiply"))]
+#[cfg(not(folded_multiply))]
 pub(crate) const fn folded_multiply(s: u64, by: u64) -> u64 {
     let b1 = s.wrapping_mul(by.swap_bytes());
     let b2 = s.swap_bytes().wrapping_mul(!by);

--- a/src/random_state.rs
+++ b/src/random_state.rs
@@ -453,14 +453,14 @@ impl BuildHasher for RandomState {
     /// implementation of [`Hash`].  The way to create a combined hash of
     /// multiple values is to call [`Hash::hash`] multiple times using the same
     /// [`Hasher`], not to call this method repeatedly and combine the results.
-    #[cfg(feature = "specialize")]
+    #[cfg(specialize)]
     #[inline]
     fn hash_one<T: Hash>(&self, x: T) -> u64 {
         RandomState::hash_one(self, x)
     }
 }
 
-#[cfg(feature = "specialize")]
+#[cfg(specialize)]
 impl RandomState {
     #[inline]
     pub(crate) fn hash_as_u64<T: Hash + ?Sized>(&self, value: &T) -> u64 {

--- a/src/specialize.rs
+++ b/src/specialize.rs
@@ -8,9 +8,9 @@ extern crate alloc;
 #[cfg(feature = "std")]
 extern crate std as alloc;
 
-#[cfg(feature = "specialize")]
+#[cfg(specialize)]
 use alloc::string::String;
-#[cfg(feature = "specialize")]
+#[cfg(specialize)]
 use alloc::vec::Vec;
 
 /// Provides a way to get an optimized hasher for a given data type.
@@ -20,7 +20,7 @@ pub(crate) trait CallHasher {
     fn get_hash<H: Hash + ?Sized>(value: &H, random_state: &RandomState) -> u64;
 }
 
-#[cfg(not(feature = "specialize"))]
+#[cfg(not(specialize))]
 impl<T> CallHasher for T
 where
     T: Hash + ?Sized,
@@ -33,7 +33,7 @@ where
     }
 }
 
-#[cfg(feature = "specialize")]
+#[cfg(specialize)]
 impl<T> CallHasher for T
 where
     T: Hash + ?Sized,
@@ -48,7 +48,7 @@ where
 
 macro_rules! call_hasher_impl_u64 {
     ($typ:ty) => {
-        #[cfg(feature = "specialize")]
+        #[cfg(specialize)]
         impl CallHasher for $typ {
             #[inline]
             fn get_hash<H: Hash + ?Sized>(value: &H, random_state: &RandomState) -> u64 {
@@ -76,7 +76,7 @@ call_hasher_impl_u64!(&i64);
 
 macro_rules! call_hasher_impl_fixed_length{
     ($typ:ty) => {
-        #[cfg(feature = "specialize")]
+        #[cfg(specialize)]
         impl CallHasher for $typ {
             #[inline]
             fn get_hash<H: Hash + ?Sized>(value: &H, random_state: &RandomState) -> u64 {
@@ -95,7 +95,7 @@ call_hasher_impl_fixed_length!(&i128);
 call_hasher_impl_fixed_length!(&usize);
 call_hasher_impl_fixed_length!(&isize);
 
-#[cfg(feature = "specialize")]
+#[cfg(specialize)]
 impl CallHasher for [u8] {
     #[inline]
     fn get_hash<H: Hash + ?Sized>(value: &H, random_state: &RandomState) -> u64 {
@@ -103,7 +103,7 @@ impl CallHasher for [u8] {
     }
 }
 
-#[cfg(feature = "specialize")]
+#[cfg(specialize)]
 impl CallHasher for Vec<u8> {
     #[inline]
     fn get_hash<H: Hash + ?Sized>(value: &H, random_state: &RandomState) -> u64 {
@@ -111,7 +111,7 @@ impl CallHasher for Vec<u8> {
     }
 }
 
-#[cfg(feature = "specialize")]
+#[cfg(specialize)]
 impl CallHasher for str {
     #[inline]
     fn get_hash<H: Hash + ?Sized>(value: &H, random_state: &RandomState) -> u64 {
@@ -119,7 +119,7 @@ impl CallHasher for str {
     }
 }
 
-#[cfg(all(feature = "specialize"))]
+#[cfg(all(specialize))]
 impl CallHasher for String {
     #[inline]
     fn get_hash<H: Hash + ?Sized>(value: &H, random_state: &RandomState) -> u64 {
@@ -133,7 +133,7 @@ mod test {
     use crate::*;
 
     #[test]
-    #[cfg(feature = "specialize")]
+    #[cfg(specialize)]
     pub fn test_specialized_invoked() {
         let build_hasher = RandomState::with_seeds(1, 2, 3, 4);
         let shortened = u64::get_hash(&0, &build_hasher);
@@ -185,7 +185,7 @@ mod test {
             str::get_hash(&"test", &build_hasher),
             String::get_hash(&"test".to_string(), &build_hasher)
         );
-        #[cfg(feature = "specialize")]
+        #[cfg(specialize)]
         assert_eq!(
             str::get_hash(&"test", &build_hasher),
             <[u8]>::get_hash("test".as_bytes(), &build_hasher)
@@ -205,7 +205,7 @@ mod test {
             str::get_hash(&&"test", &build_hasher),
             String::get_hash(&"test".to_string(), &build_hasher)
         );
-        #[cfg(feature = "specialize")]
+        #[cfg(specialize)]
         assert_eq!(
             str::get_hash(&&"test", &build_hasher),
             <[u8]>::get_hash(&"test".to_string().into_bytes(), &build_hasher)

--- a/tests/bench.rs
+++ b/tests/bench.rs
@@ -1,4 +1,4 @@
-#![cfg_attr(feature = "specialize", feature(build_hasher_simple_hash_one))]
+#![cfg_attr(specialize, feature(build_hasher_simple_hash_one))]
 
 use ahash::{AHasher, RandomState};
 use criterion::*;

--- a/tests/map_tests.rs
+++ b/tests/map_tests.rs
@@ -1,4 +1,4 @@
-#![cfg_attr(feature = "specialize", feature(build_hasher_simple_hash_one))]
+#![cfg_attr(specialize, feature(build_hasher_simple_hash_one))]
 
 use std::hash::{BuildHasher, Hash, Hasher};
 
@@ -151,13 +151,13 @@ fn check_for_collisions<H: Hash, B: BuildHasher>(build_hasher: &B, items: &[H], 
     );
 }
 
-#[cfg(feature = "specialize")]
+#[cfg(specialize)]
 #[allow(unused)] // False positive
 fn hash<H: Hash, B: BuildHasher>(b: &H, build_hasher: &B) -> u64 {
     build_hasher.hash_one(b)
 }
 
-#[cfg(not(feature = "specialize"))]
+#[cfg(not(specialize))]
 #[allow(unused)] // False positive
 fn hash<H: Hash, B: BuildHasher>(b: &H, build_hasher: &B) -> u64 {
     let mut hasher = build_hasher.build_hasher();


### PR DESCRIPTION
Replace `cfg(feature = "$X")` with `cfg($X)` for each undeclared feature X. Declare each such cfg in build.rs. This silences the warnings in recent toolchains.