### PR TITLE
Eliminate an unused use of `convert!`.

### DIFF
--- a/src/convert.rs
+++ b/src/convert.rs
@@ -41,7 +41,6 @@ convert!([u128; 2], [u64; 4]);
 convert!([u128; 2], [u8; 32]);
 convert!(u128, [u64; 2]);
 convert_primitive_bytes!(u128, [u8; 16]);
-convert!([u64; 2], [u32; 4]);
 #[cfg(test)]
 convert!([u64; 2], [u8; 16]);
 convert_primitive_bytes!(u64, [u8; 8]);


### PR DESCRIPTION
This is unused, at least according to CI. I am not sure why it wasn't removed in my earlier PR that removed many others.