### PR TITLE
Fix some typos

### DIFF
--- a/src/aes_hash.rs
+++ b/src/aes_hash.rs
@@ -27,7 +27,7 @@ impl AHasher {
     ///
     /// Normally hashers are created via `AHasher::default()` for fixed keys or `RandomState::new()` for randomly
     /// generated keys and `RandomState::with_seeds(a,b)` for seeds that are set and can be reused. All of these work at
-    /// map creation time (and hence don't have any overhead on a per-item bais).
+    /// map creation time (and hence don't have any overhead on a per-item basis).
     ///
     /// This method directly creates the hasher instance and performs no transformation on the provided seeds. This may
     /// be useful where a HashBuilder is not desired, such as for testing purposes.

--- a/src/fallback_hash.rs
+++ b/src/fallback_hash.rs
@@ -80,7 +80,7 @@ impl AHasher {
     /// https://en.wikipedia.org/wiki/Multiply-with-carry_pseudorandom_number_generator
     /// If the multiple is chosen well, this creates a long period, decent quality PRNG.
     /// Notice that this function is equivalent to this except the `buffer`/`state` is being xored with each
-    /// new block of data. In the event that data is all zeros, it is exactly equivalent to a MWC PRNG.
+    /// new block of data. In the event that data is all zeros, it is exactly equivalent to an MWC PRNG.
     ///
     /// This is impervious to attack because every bit buffer at the end is dependent on every bit in
     /// `new_data ^ buffer`. For example suppose two inputs differed in only the 5th bit. Then when the
@@ -88,8 +88,8 @@ impl AHasher {
     /// 2^5 * MULTIPLE. However in the next step bits 65-128 are turned into a separate 64 bit value. So the
     /// differing bits will be in the lower 6 bits of this value. The two intermediate values that differ in
     /// bits 5-63 and in bits 0-5 respectively get added together. Producing an output that differs in every
-    /// bit. The addition carries in the multiplication and at the end additionally mean that the even if an
-    /// attacker somehow knew part of (but not all) the contents of the buffer before hand,
+    /// bit. The addition carries in the multiplication and at the end additionally mean that even if an
+    /// attacker somehow knew part of (but not all) the contents of the buffer beforehand,
     /// they would not be able to predict any of the bits in the buffer at the end.
     #[inline(always)]
     fn update(&mut self, new_data: u64) {
@@ -142,7 +142,7 @@ impl Hasher for AHasher {
 
     #[inline]
     fn write_u64(&mut self, i: u64) {
-        self.update(i as u64);
+        self.update(i);
     }
 
     #[inline]

--- a/src/hash_quality_test.rs
+++ b/src/hash_quality_test.rs
@@ -414,7 +414,7 @@ mod fallback_tests {
     }
 
     #[test]
-    fn fallback_finish_is_consistant() {
+    fn fallback_finish_is_consistent() {
         test_finish_is_consistent(AHasher::test_with_keys)
     }
 
@@ -511,7 +511,7 @@ mod aes_tests {
     }
 
     #[test]
-    fn aes_finish_is_consistant() {
+    fn aes_finish_is_consistent() {
         test_finish_is_consistent(AHasher::test_with_keys)
     }
 

--- a/src/hash_set.rs
+++ b/src/hash_set.rs
@@ -53,7 +53,7 @@ impl<T> AHashSet<T, RandomState> {
         AHashSet(HashSet::with_hasher(RandomState::new()))
     }
 
-    /// This craetes a hashset with the specified capacity using [RandomState::new].
+    /// This creates a hashset with the specified capacity using [RandomState::new].
     /// See the documentation in [RandomSource] for notes about key strength.
     pub fn with_capacity(capacity: usize) -> Self {
         AHashSet(HashSet::with_capacity_and_hasher(capacity, RandomState::new()))
@@ -293,7 +293,7 @@ where
     }
 }
 
-/// NOTE: For safety this trait impl is only available available if either of the flags `runtime-rng` (on by default) or
+/// NOTE: For safety this trait impl is only available if either of the flags `runtime-rng` (on by default) or
 /// `compile-time-rng` are enabled. This is to prevent weakly keyed maps from being accidentally created. Instead one of
 /// constructors for [RandomState] must be used.
 #[cfg(any(feature = "compile-time-rng", feature = "runtime-rng", feature = "no-rng"))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 //! AHash is a high performance keyed hash function.
 //!
 //! It quickly provides a high quality hash where the result is not predictable without knowing the Key.
-//! AHash works with `HashMap` to hash keys, but without allowing for the possibility that an malicious user can
+//! AHash works with `HashMap` to hash keys, but without allowing for the possibility that a malicious user can
 //! induce a collision.
 //!
 //! # How aHash works

--- a/src/operations.rs
+++ b/src/operations.rs
@@ -364,10 +364,10 @@ mod test {
 
     #[test]
     fn test_add_length() {
-        let enc : [u64; 2] = [50, u64::MAX];
-        let mut enc : u128 = enc.convert();
+        let enc: [u64; 2] = [50, u64::MAX];
+        let mut enc: u128 = enc.convert();
         add_in_length(&mut enc, u64::MAX);
-        let enc : [u64; 2] = enc.convert();
+        let enc: [u64; 2] = enc.convert();
         assert_eq!(enc[1], u64::MAX);
         assert_eq!(enc[0], 49);
     }

--- a/src/random_state.rs
+++ b/src/random_state.rs
@@ -18,10 +18,10 @@ cfg_if::cfg_if! {
     }
 }
 
-#[cfg(feature = "atomic-polyfill")]
-use portable_atomic as atomic;
 #[cfg(not(feature = "atomic-polyfill"))]
 use core::sync::atomic;
+#[cfg(feature = "atomic-polyfill")]
+use portable_atomic as atomic;
 
 use alloc::boxed::Box;
 use atomic::{AtomicUsize, Ordering};
@@ -292,7 +292,7 @@ impl RandomState {
     }
 
     /// Allows for explicitly setting the seeds to used.
-    /// All `RandomState`s created with the same set of keys key will produce identical hashers.
+    /// All `RandomState`s created with the same set of keys will produce identical hashers.
     /// (In contrast to `generate_with` above)
     ///
     /// Note: If DOS resistance is desired one of these should be a decent quality random number.
@@ -364,7 +364,7 @@ impl RandomState {
 ///
 /// This is the same as [RandomState::new()]
 ///
-/// NOTE: For safety this trait impl is only available available if either of the flags `runtime-rng` (on by default) or
+/// NOTE: For safety this trait impl is only available if either of the flags `runtime-rng` (on by default) or
 /// `compile-time-rng` are enabled. This is to prevent weakly keyed maps from being accidentally created. Instead one of
 /// constructors for [RandomState] must be used.
 #[cfg(any(feature = "compile-time-rng", feature = "runtime-rng", feature = "no-rng"))]
@@ -379,7 +379,7 @@ impl BuildHasher for RandomState {
     type Hasher = AHasher;
 
     /// Constructs a new [AHasher] with keys based on this [RandomState] object.
-    /// This means that two different [RandomState]s will will generate
+    /// This means that two different [RandomState]s will generate
     /// [AHasher]s that will return different hashcodes, but [Hasher]s created from the same [BuildHasher]
     /// will generate the same hashes for the same input data.
     ///

--- a/src/specialize.rs
+++ b/src/specialize.rs
@@ -74,7 +74,7 @@ call_hasher_impl_u64!(&i16);
 call_hasher_impl_u64!(&i32);
 call_hasher_impl_u64!(&i64);
 
-macro_rules! call_hasher_impl_fixed_length{
+macro_rules! call_hasher_impl_fixed_length {
     ($typ:ty) => {
         #[cfg(specialize)]
         impl CallHasher for $typ {

--- a/tests/map_tests.rs
+++ b/tests/map_tests.rs
@@ -200,7 +200,6 @@ fn test_ahash_alias_set_construction() {
     set.insert(1);
 }
 
-
 #[cfg(feature = "std")]
 #[test]
 fn test_key_ref() {
@@ -228,8 +227,8 @@ fn test_key_ref() {
 #[cfg(feature = "std")]
 #[test]
 fn test_byte_dist() {
-    use rand::{SeedableRng, Rng, RngCore};
     use pcg_mwc::Mwc256XXA64;
+    use rand::{Rng, RngCore, SeedableRng};
 
     let mut r = Mwc256XXA64::seed_from_u64(0xe786_c22b_119c_1479);
     let mut lowest = 2.541;
@@ -274,7 +273,6 @@ fn test_byte_dist() {
     assert!(lowest > 1.9, "Lowest = {}", lowest);
     assert!(highest < 3.9, "Highest = {}", highest);
 }
-
 
 fn ahash_vec<H: Hash>(b: &Vec<H>) -> u64 {
     let mut total: u64 = 0;


### PR DESCRIPTION
Other non-typo changes are made by running `cargo fmt`.