### PR TITLE
Added wasm32-unknown-unknown build options for getrandom.

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,4 @@
+# Configuration for WASM support
+# This enables the wasm_js backend for getrandom when targeting wasm32-unknown-unknown
+[target.wasm32-unknown-unknown]
+rustflags = ['--cfg', 'getrandom_backend="wasm_js"']

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,6 +89,10 @@ zerocopy = { version = "0.8.24", default-features = false, features = ["simd"] }
 [target.'cfg(not(all(target_arch = "arm", target_os = "none")))'.dependencies]
 once_cell = { version = "1.18.0", default-features = false, features = ["alloc"] }
 
+# WASM-specific dependencies to enable wasm_js feature for getrandom
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+getrandom = { version = "0.3.3", optional = true, features = ["wasm_js"] }
+
 [dev-dependencies]
 no-panic = "0.1.10"
 criterion = {version =  "0.3.2", features = ["html_reports"] }


### PR DESCRIPTION
Hi,

I put this together to address issue #276.  It adds both the getrandom feature flag and the RUSTFLAGS argument needed. I'm happy to take feedback and adjust the PR as necessary to make it suitable.