### PR TITLE
Update Cargo.toml for getrandom on wasm

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,7 +90,7 @@ zerocopy = { version = "0.8.24", default-features = false, features = ["simd"] }
 once_cell = { version = "1.18.0", default-features = false, features = ["alloc"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-getrandom = { version = "0.3.4", features = ["wasm_js"] }
+getrandom = { version = "0.3.1", features = ["wasm_js"] }
 
 [dev-dependencies]
 no-panic = "0.1.10"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,6 +89,9 @@ zerocopy = { version = "0.8.24", default-features = false, features = ["simd"] }
 [target.'cfg(not(all(target_arch = "arm", target_os = "none")))'.dependencies]
 once_cell = { version = "1.18.0", default-features = false, features = ["alloc"] }
 
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+getrandom = { version = "0.3.4", features = ["wasm_js"] }
+
 [dev-dependencies]
 no-panic = "0.1.10"
 criterion = {version =  "0.3.2", features = ["html_reports"] }


### PR DESCRIPTION
fix

```
194 | /                 compile_error!(concat!(
195 | |                     "The wasm32-unknown-unknown targets are not supported by default; \
196 | |                     you may need to enable the \"wasm_js\" configuration flag. Note \
197 | |                     that enabling the `wasm_js` feature flag alone is insufficient. \
198 | |                     For more information see: \
199 | |                     https://docs.rs/getrandom/", env!("CARGO_PKG_VERSION"), "/#webassembly-support"
200 | |                 ));
```

